### PR TITLE
Add search function for milestone components

### DIFF
--- a/frontend/src/lib/components/DataDisplay/GalleryDisplay.svelte
+++ b/frontend/src/lib/components/DataDisplay/GalleryDisplay.svelte
@@ -1,13 +1,7 @@
 <script lang="ts">
-	import { Gallery, Heading, Search } from 'flowbite-svelte';
-
-	export let filterData = (data, col, searchTerm) => {
-		if (searchTerm === '') {
-			return data;
-		} else {
-			return data.filter((item) => item[col].toLowerCase().includes(searchTerm.toLowerCase()));
-		}
-	};
+	import { Button, Dropdown, DropdownItem, Gallery, Heading, Search } from 'flowbite-svelte';
+	import { ChevronDownOutline } from 'flowbite-svelte-icons';
+	import { tick } from 'svelte';
 
 	export let data;
 	export let header: string | null = null;
@@ -15,7 +9,25 @@
 	export let withSearch = true;
 	export let searchableCol = '';
 	export let componentProps;
-	export let searchPlaceHolder = 'Durchsuchen';
+
+	export let searchData = [
+		{
+			label: 'Alle',
+			placeholder: 'Durchsuchen',
+			filterFunction: (data: any[], col: any, searchTerm: string): any[] => {
+				if (searchTerm === '') {
+					return data;
+				} else {
+					return data.filter((item) => item[col].toLowerCase().includes(searchTerm.toLowerCase()));
+				}
+			}
+		}
+	];
+
+	let searchCategory: string = searchData[0].label;
+	let searchPlaceHolder: string = searchData[0].placeholder;
+	let filterData = searchData[0].filterFunction;
+	let dropdownOpen: boolean = false;
 
 	// dynamic statements
 	let searchTerm = '';
@@ -41,8 +53,42 @@
 	{/if}
 
 	{#if withSearch}
-		<form class="m-2 w-full p-4">
-			<Search size="md" placeholder={searchPlaceHolder} bind:value={searchTerm} />
+		<form class="m-2 flex w-full rounded p-4">
+			{#if searchData.length > 1}
+				<!-- after example: https://flowbite-svelte.com/docs/forms/search-input#Search_with_dropdown -->
+				<div class="relative">
+					<Button
+						class="border-primary-700 h-full whitespace-nowrap rounded-e-none border border-e-0"
+					>
+						{searchCategory}
+						<ChevronDownOutline class="ms-2.5 h-2.5 w-2.5" />
+					</Button>
+					<Dropdown classContainer="flex w-auto" bind:open={dropdownOpen}>
+						{#each searchData as { label, placeholder, filterFunction }}
+							<DropdownItem
+								on:click={async () => {
+									searchCategory = label;
+									searchPlaceHolder = placeholder;
+									filterData = filterFunction;
+									dropdownOpen = false;
+									await tick();
+								}}
+								class={searchCategory === label ? 'underline' : ''}
+							>
+								{label}
+							</DropdownItem>
+						{/each}
+					</Dropdown>
+				</div>
+				<Search
+					class="rounded-none py-2.5"
+					size="md"
+					placeholder={searchPlaceHolder}
+					bind:value={searchTerm}
+				/>
+			{:else}
+				<Search size="md" placeholder={searchPlaceHolder} bind:value={searchTerm} />
+			{/if}
 		</form>
 	{/if}
 

--- a/frontend/src/lib/components/DataDisplay/GalleryDisplay.svelte
+++ b/frontend/src/lib/components/DataDisplay/GalleryDisplay.svelte
@@ -81,13 +81,18 @@
 					</Dropdown>
 				</div>
 				<Search
-					class="rounded-none py-2.5"
+					class="rounded-e rounded-s-none py-2.5"
 					size="md"
 					placeholder={searchPlaceHolder}
 					bind:value={searchTerm}
 				/>
 			{:else}
-				<Search size="md" placeholder={searchPlaceHolder} bind:value={searchTerm} />
+				<Search
+					size="md"
+					class="rounded py-2.5"
+					placeholder={searchPlaceHolder}
+					bind:value={searchTerm}
+				/>
 			{/if}
 		</form>
 	{/if}

--- a/frontend/src/lib/components/MilestoneGroup.svelte
+++ b/frontend/src/lib/components/MilestoneGroup.svelte
@@ -2,25 +2,10 @@
 	import Breadcrumbs from '$lib/components/Breadcrumbs.svelte';
 	import CardDisplay from '$lib/components/DataDisplay/CardDisplay.svelte';
 	import GalleryDisplay from '$lib/components/DataDisplay/GalleryDisplay.svelte';
+
 	export let breadcrumbdata: any[] = [];
 	export let milestonedata: any[] = [];
-
-	function filterData(data: object[], dummy: any, key: string): object[] {
-		if (key === '') {
-			return data;
-		} else {
-			return data.filter((item) => {
-				// button label contains info about completion status => use for search
-				if (key === completeKey) {
-					return item.progress === 1;
-				} else if (key === incompleteKey) {
-					return item.progress < 1;
-				} else {
-					return item.header.toLowerCase().includes(key.toLowerCase());
-				}
-			});
-		}
-	}
+	export let searchData: any[] = [];
 
 	// FIXME:styling has no business being here... not sure where to put it though given thatparts of it are data dependent
 	export function createStyle(data) {
@@ -54,9 +39,8 @@
 			itemComponent={CardDisplay}
 			searchableCol={'header'}
 			componentProps={createStyle(milestonedata)}
-			searchPlaceHolder={`Nach Status (${completeKey}/${incompleteKey}) oder Titel durchsuchen`}
 			withSearch={true}
-			{filterData}
+			{searchData}
 		/>
 	</div>
 </div>

--- a/frontend/src/lib/components/MilestoneOverview.svelte
+++ b/frontend/src/lib/components/MilestoneOverview.svelte
@@ -5,23 +5,6 @@
 	import GalleryDisplay from '$lib/components/DataDisplay/GalleryDisplay.svelte';
 	import { CheckCircleSolid, ExclamationCircleSolid } from 'flowbite-svelte-icons';
 
-	function filterData(data: object[], dummy: any, key: string): object[] {
-		if (key === '') {
-			return data;
-		} else {
-			return data.filter((item) => {
-				// button label contains info about completion status => use for search
-				if (key === completeKey) {
-					return item.complete === true;
-				} else if (key === incompleteKey) {
-					return item.complete === false;
-				} else {
-					return item.header.toLowerCase().includes(key.toLowerCase());
-				}
-			});
-		}
-	}
-
 	// FIXME: this must go eventually. Either must happen in the backend or there
 	// should be in a refactored version of the card component
 	function convertData(data: object[]): object[] {
@@ -30,6 +13,8 @@
 				header: item.title,
 				href: `${base}/milestone`, // hardcoded link for the moment
 				complete: item.answer !== null,
+				summary: item.desc,
+				answer: item.answer,
 				auxilliary: item.answer !== null ? CheckCircleSolid : ExclamationCircleSolid
 			};
 		});
@@ -38,6 +23,7 @@
 	const completeKey = 'fertig';
 	const incompleteKey = 'unfertig';
 	export let breadcrumbdata: object[] = [];
+	export let searchData: any[];
 	export let data: object[] = [];
 	const rawdata = convertData(data).sort((a, b) => a.complete - b.complete); // FIXME: the convert step should not be here and will be handeled backend-side
 </script>
@@ -60,9 +46,8 @@
 					}
 				};
 			})}
-			searchPlaceHolder={`Nach Status (${completeKey}/${incompleteKey}) oder Titel durchsuchen`}
 			withSearch={true}
-			{filterData}
+			{searchData}
 		/>
 	</div>
 </div>

--- a/frontend/src/routes/milestonegroup/+page.svelte
+++ b/frontend/src/routes/milestonegroup/+page.svelte
@@ -23,14 +23,55 @@
 		}
 	];
 
+	const milestoneData = [
+		{
+			number: 1,
+			title: 'Alleine von Stufe/Absatz springen',
+			desc: 'Kind springt mit beiden Beinen gleichzeitig hoch und überwindet im Sprung freihändig einen (kleinen) Absatz oder eine Stufe. Es kommt sicher wieder im Stand auf.',
+			observation:
+				'Beobachten Sie, ob das Kind spontan oder nach Aufforderung von einer Treppenstufe oder einem ähnlich hohen Absatz springt! Es sollte tatsächlich mit beiden Beinen gleichzeitig losspringen, sich nirgends festhalten und beim Landen nicht mit der Hand abfangen. Sie sollten es beim Springen auch nicht an die Hand nehmen müssen. Wurde dieses Verhalten mehrmals sicher ausgeführt, gilt der Meilenstein zuverlässig gekonnt.  Ist das Kind noch leicht unsicher, springt meist mit beiden Beinen versetzt los, oder berührt beim Landen mit der Hand den Boden, ist das Verhalten weitgehend gekonnt. Wagt es den Sprung nur, wenn man seine Hand hält und/oder führt es den Sprung noch unsauber aus, ist das Verhalten in Ansätzen gekonnt. In allen anderen Fällen gilt der Meilenstein als noch nicht gekonnt.',
+			help: 'Beim Treppengehen im Haus, beim Spazierengehen oder auf dem Spielplatz bieten sich vielfältige Gelegenheiten, Kinder zum Springen von einem Absatz (z.B. einem höheren Bordstein. einem Holzstamm, oder einem Stein) zu ermutigen. Machen Sie Ihrem Kind die Bewegung vor oder führen Sie sie gemeinsam mit dem Kind durch. Nehmen Sie das Kind dafür zunächst bei an die Hand. Später können sie die Hand immer lockerer mitführen und die Eigenbewegung des Kindes nur noch passiv begleiten. So kann das Kind am besten selbst herausfinden, wie es seine Arme einsetzen muss, um Schwung zu holen und beim Landen das Gleichgewicht zu finden. Ist das Springen an der Hand sicher, lösen Sie die Hand ganz und stellen Sie sich gegenüber dem Kind hin, damit es weiß, dass es im Notfall aufgefangen wird.',
+			imgs: ['baby0.jpg', 'baby1.jpg', 'baby2.jpg'],
+			answer: 'Vollständig gekonnt'
+		},
+		{
+			number: 2,
+			title: 'Das Köpfchen alleine heben',
+			desc: 'Kind liegt auf dem Bauch, hält die Arme angewinkelt neben dem Körper und hebt sein Köpfchen aus eigener Kraft so hoch, dass das Kinn nicht mehr die Auflage berührt. Diese Position kann es mehr als 3 Sekunden halten.',
+			observation: 'Hier kommt der Beobachtungshilfetext hin',
+			help: 'Hier kommt der Förderhilfetext hin',
+			imgs: ['baby1.jpg'],
+			answer: null
+		},
+		{
+			number: 3,
+			title: 'Den Kopf frei bewegen',
+			desc: 'Kind kann seinen Kopf frei halten und bewegen, wenn es z.B. auf dem Schoß sitzt. Wenn man seinen Körper ein wenig schräg hält, gleicht es diese Bewegung mit dem Kopf aus. Der Kopf wackelt kaum oder gar nicht, wenn das Kind ihn dreht.',
+			observation: 'Hier kommt der Beobachtungshilfetext hin',
+			help: 'Hier kommt der Förderhilfetext hin',
+			imgs: ['baby2.jpg'],
+			answer: 'In Ansätzen gekonnt'
+		},
+		{
+			number: 4,
+			title: 'Sich in Bauchlage mit gestreckten Armen aufstützen',
+			desc: 'Kind liegt auf dem Bauch. Es stützt sich mit beiden Armen gestreckt von der Unterlage ab und hebt seinen Rücken an, um den Kopf aufrecht zu halten. Schultern und Brust liegen für mehr als 3 Sekunden nicht mehr auf der Unterlage.',
+			observation: 'Hier kommt der Beobachtungshilfetext hin',
+			help: 'Hier kommt der Förderhilfetext hin',
+			imgs: ['baby3.jpg'],
+			answer: null
+		}
+	];
+
 	// this is a list of data that can be fetched by the component later.
-	const milestonedata: any[] = [
+	const surveyData: any[] = [
 		{
 			header: 'Grobmotorik',
 			summary: 'something something',
 			image: imgJump,
 			href: `${base}/milestoneoverview`,
-			progress: 0.75
+			progress: 0.75,
+			milestoneData: milestoneData
 		},
 		{
 			header: 'Feinmotorik',
@@ -38,28 +79,32 @@
 				'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt',
 			image: null,
 			href: `${base}/milestoneoverview`,
-			progress: 1.0
+			progress: 1.0,
+			milestoneData: milestoneData
 		},
 		{
 			header: 'Geistige Grundfunktionen',
 			summary: 'something something',
 			image: imgHead,
 			href: `${base}/milestoneoverview`,
-			progress: 1.0
+			progress: 1.0,
+			milestoneData: milestoneData
 		},
 		{
 			header: 'Höhere Denkfunktionen',
 			summary: 'something something',
 			image: null,
 			href: `${base}/milestoneoverview`,
-			progress: 1.0
+			progress: 1.0,
+			milestoneData: milestoneData
 		},
 		{
 			header: 'Sprache',
 			summary: 'how much noise the child makes',
 			image: null,
 			href: `${base}/milestoneoverview`,
-			progress: 0.5
+			progress: 0.5,
+			milestoneData: milestoneData
 		},
 		{
 			header: 'Soziale Entwicklung',
@@ -67,21 +112,24 @@
 				'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit.',
 			image: imgHead,
 			href: `${base}/milestoneoverview`,
-			progress: 0.3
+			progress: 0.3,
+			milestoneData: milestoneData
 		},
 		{
 			header: 'Selbstregulation',
 			summary: 'something something',
 			image: null,
 			href: `${base}/milestoneoverview`,
-			progress: 0.6
+			progress: 0.6,
+			milestoneData: milestoneData
 		},
 		{
 			header: 'Emotionen',
 			summary: 'something something',
 			image: null,
 			href: `${base}/milestoneoverview`,
-			progress: 0.9
+			progress: 0.9,
+			milestoneData: milestoneData
 		},
 		{
 			header: 'Vorläuferfertigkeiten Schule',
@@ -89,11 +137,123 @@
 				'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit.',
 			image: null,
 			href: `${base}/milestoneoverview`,
-			progress: 0.3
+			progress: 0.3,
+			milestoneData: milestoneData
+		}
+	];
+
+	interface MilestoneData {
+		number: 4;
+		title: string;
+		desc: string;
+		observation: string;
+		help: string;
+		answer: string;
+	}
+
+	interface DataElement {
+		header: string;
+		summary: string;
+		milestoneData: any;
+		progress: number;
+		[key: string]: any;
+	}
+
+	function searchByStatus(data: DataElement[], dummy: any, key: string): DataElement[] {
+		if (key === '') {
+			return data;
+		} else {
+			return data.filter((item) => {
+				// button label contains info about completion status => use for search
+				if (key === 'fertig') {
+					return item.progress === 1;
+				} else if (key === 'unfertig') {
+					return item.progress < 1;
+				} else {
+					return item.header.toLowerCase().includes(key.toLowerCase());
+				}
+			});
+		}
+	}
+
+	function searchBySurvey(data: DataElement[], dummy: any, key: string): DataElement[] {
+		if (key === '') {
+			return data;
+		} else {
+			return data.filter((item) => {
+				return item.header.toLowerCase().includes(key.toLowerCase());
+			});
+		}
+	}
+
+	function searchBySurveyDescription(data: DataElement[], dummy: any, key: string): DataElement[] {
+		if (key === '') {
+			return data;
+		} else {
+			return data.filter((item) => {
+				return item.summary.toLowerCase().includes(key.toLowerCase());
+			});
+		}
+	}
+
+	function searchByMilestone(data: DataElement[], dummy: any, key: string): DataElement[] {
+		if (key === '') {
+			return data;
+		} else {
+			return data.filter((item) => {
+				return item.milestoneData.some((element: MilestoneData) =>
+					element.title.toLowerCase().includes(key.toLowerCase())
+				);
+			});
+		}
+	}
+
+	// README: this is slow and quite a bit of work because a lot of text has to be searched. Kill it?
+	function searchAll(data: DataElement[], dummy: any, key: string): DataElement[] {
+		const surveyRes = searchBySurvey(data, dummy, key);
+		const statusRes = searchByStatus(data, dummy, key);
+		const milestoneRes = searchByMilestone(data, dummy, key);
+		const descrRes = searchBySurveyDescription(data, dummy, key);
+
+		return [
+			...new Set([
+				...searchBySurvey(data, dummy, key),
+				...searchByStatus(data, dummy, key),
+				...searchByMilestone(data, dummy, key),
+				...searchBySurveyDescription(data, dummy, key)
+			])
+		];
+	}
+
+	const searchData: any[] = [
+		{
+			label: 'Alle',
+			placeholder: 'Alle Kategorien durchsuchen',
+			filterFunction: searchAll
+		},
+		{
+			label: 'Bereich',
+			placeholder: 'Nach Beobachtungsbereich suchen',
+			filterFunction: searchBySurvey
+		},
+		{
+			label: 'Bereichsbeschreibung',
+			placeholder: 'Beschreibung von Bereichen durchsuchen',
+			filterFunction: searchBySurveyDescription
+		},
+		{
+			label: 'Meilensteine',
+			placeholder: 'Nach Meilenstein suchen',
+			filterFunction: searchByMilestone
+		},
+		{
+			label: 'Status',
+			placeholder: 'Bereiche nach Status durchsuchen (fertig/unfertig)',
+			filterFunction: searchByStatus
 		}
 	];
 </script>
 
 <div class="flex items-center justify-center">
-	<MilestoneGroup {breadcrumbdata} {milestonedata} />
+	<MilestoneGroup {breadcrumbdata} {searchData} milestonedata={surveyData} />
 </div>

--- a/frontend/src/routes/milestonegroup/+page.svelte
+++ b/frontend/src/routes/milestonegroup/+page.svelte
@@ -210,11 +210,6 @@
 
 	// README: this is slow and quite a bit of work because a lot of text has to be searched. Kill it?
 	function searchAll(data: DataElement[], dummy: any, key: string): DataElement[] {
-		const surveyRes = searchBySurvey(data, dummy, key);
-		const statusRes = searchByStatus(data, dummy, key);
-		const milestoneRes = searchByMilestone(data, dummy, key);
-		const descrRes = searchBySurveyDescription(data, dummy, key);
-
 		return [
 			...new Set([
 				...searchBySurvey(data, dummy, key),

--- a/frontend/src/routes/milestoneoverview/+page.svelte
+++ b/frontend/src/routes/milestoneoverview/+page.svelte
@@ -68,6 +68,98 @@
 	const desc =
 		'Hier geht es darum, zu beschreiben, wie sich das Kind fortbewegt Und seinen Körper (Rumpf, Arme, Beine) kontrollieren kann.';
 	const progress = 0.5;
+
+	interface MilestoneData {
+		header: string;
+		href: string;
+		summary: string;
+		auxilliary: string;
+		complete: boolean;
+		answer: string;
+	}
+
+	function searchStatus(data: MilestoneData[], dummy: any, key: string): MilestoneData[] {
+		if (key === '') {
+			return data;
+		} else {
+			return data.filter((item) => {
+				// button label contains info about completion status => use for search
+				if (key === 'fertig') {
+					return item.complete === true;
+				} else if (key === 'unfertig') {
+					return item.complete === false;
+				}
+			});
+		}
+	}
+
+	function searchDescription(data: MilestoneData[], dummy: any, key: string): MilestoneData[] {
+		if (key === '') {
+			return data;
+		} else {
+			return data.filter((item) => {
+				return item.summary.toLowerCase().includes(key.toLowerCase());
+			});
+		}
+	}
+
+	function searchTitle(data: MilestoneData[], dummy: any, key: string): MilestoneData[] {
+		if (key === '') {
+			return data;
+		} else {
+			return data.filter((item) => {
+				return item.header.toLowerCase().includes(key.toLowerCase());
+			});
+		}
+	}
+
+	function searchAnswer(data: MilestoneData[], dummy: any, key: string): MilestoneData[] {
+		if (key === '') {
+			return data;
+		} else {
+			return data.filter((item) => {
+				return item.answer === null ? false : item.answer.toLowerCase().includes(key.toLowerCase());
+			});
+		}
+	}
+
+	function searchAll(data: MilestoneData[], dummy: any, key: string): MilestoneData[] {
+		return [
+			...new Set([
+				...searchDescription(data, dummy, key),
+				...searchStatus(data, dummy, key),
+				...searchTitle(data, dummy, key),
+				...searchAnswer(data, dummy, key)
+			])
+		];
+	}
+	const searchData = [
+		{
+			label: 'Alle',
+			placeholder: 'Alle Kategorien durchsuchen',
+			filterFunction: searchAll
+		},
+		{
+			label: 'Status',
+			placeholder: 'Nach Status durchsuchen',
+			filterFunction: searchStatus
+		},
+		{
+			label: 'Anwort',
+			placeholder: 'Nach Antwort durchsuchen',
+			filterFunction: searchAnswer
+		},
+		{
+			label: 'Titel',
+			placeholder: 'Nach Meilenstein durchsuchen',
+			filterFunction: searchTitle
+		},
+		{
+			label: 'Beschreibung',
+			placeholder: 'Beschreibungen durchsuchen',
+			filterFunction: searchDescription
+		}
+	];
 </script>
 
-<MilestoneOverview {breadcrumbdata} {data} />
+<MilestoneOverview {breadcrumbdata} {data} {searchData} />


### PR DESCRIPTION
- makes `GalleryDisplay` accept an additional variable `searchData` (an array of objects) that defines categories of data to be searched for. 
- add a dropdown button to select the search category. Per default the first is used. 
  - TODO remains: need to focus input field automatically when category is selected, but usual `bind:this={thing}` => `thing.focus()`  didn´t work. Left for another PR that fixes this kind of usability stuff 
-  Implement a number of search categories for `milestoneoverview` and `milestonegroup`. Which ones we want actually can be decided quickly, since we just need to exchange an element in an array to add or remove them. 