### PR TITLE
Add de/en languages to the database on startup if there are no languages

### DIFF
--- a/frontend/src/lib/components/Admin/Languages.svelte
+++ b/frontend/src/lib/components/Admin/Languages.svelte
@@ -73,12 +73,12 @@
 					</TableBodyCell>
 					<TableBodyCell>
 						{#if lang_id > 2}
-						<DeleteButton
-							onclick={() => {
-								currentLanguageId = `${lang_id}`;
-								showDeleteModal = true;
-							}}
-						/>
+							<DeleteButton
+								onclick={() => {
+									currentLanguageId = `${lang_id}`;
+									showDeleteModal = true;
+								}}
+							/>
 						{/if}
 					</TableBodyCell>
 				</TableBodyRow>

--- a/frontend/src/lib/components/Admin/Languages.svelte
+++ b/frontend/src/lib/components/Admin/Languages.svelte
@@ -72,12 +72,14 @@
 						{ISO6391.getNativeName(lang)}
 					</TableBodyCell>
 					<TableBodyCell>
+						{#if lang_id > 2}
 						<DeleteButton
 							onclick={() => {
-								currentLanguageId = lang_id;
+								currentLanguageId = `${lang_id}`;
 								showDeleteModal = true;
 							}}
 						/>
+						{/if}
 					</TableBodyCell>
 				</TableBodyRow>
 			{/each}

--- a/mondey_backend/src/mondey_backend/databases/milestones.py
+++ b/mondey_backend/src/mondey_backend/databases/milestones.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+from sqlmodel import Session
 from sqlmodel import SQLModel
 from sqlmodel import create_engine
+from sqlmodel import select
 
+from ..models.milestones import Language
 from ..settings import app_settings
 
 engine = create_engine(
@@ -13,3 +16,9 @@ engine = create_engine(
 
 def create_database():
     SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        # add "de" and "en" Languages if no languages are present in the database:
+        if session.exec(select(Language)).first() is None:
+            session.add(Language(lang="de"))
+            session.add(Language(lang="en"))
+            session.commit()

--- a/mondey_backend/src/mondey_backend/routers/admin.py
+++ b/mondey_backend/src/mondey_backend/routers/admin.py
@@ -4,6 +4,7 @@ import json
 import pathlib
 
 from fastapi import APIRouter
+from fastapi import HTTPException
 from fastapi import UploadFile
 from sqlmodel import col
 from sqlmodel import select
@@ -42,6 +43,10 @@ def create_router() -> APIRouter:
 
     @router.delete("/languages/{language_id}")
     def delete_language(session: SessionDep, language_id: int):
+        if language_id <= 2:
+            raise HTTPException(
+                status_code=400, detail="DE and EN languages cannot be deleted"
+            )
         language = get(session, Language, language_id)
         session.delete(language)
         session.commit()

--- a/mondey_backend/tests/routers/test_admin.py
+++ b/mondey_backend/tests/routers/test_admin.py
@@ -12,9 +12,22 @@ def test_post_language(admin_client: TestClient):
 
 
 def test_delete_language(admin_client: TestClient):
-    response = admin_client.delete("/admin/languages/2")
+    response = admin_client.delete("/admin/languages/3")
     assert response.status_code == 200
-    assert admin_client.get("/languages").json() == {"de": 1, "fr": 3}
+    assert admin_client.get("/languages").json() == {"de": 1, "en": 2}
+
+
+@pytest.mark.parametrize("lang_id", [1, 2])
+def test_delete_language_invalid_de_en_cannot_be_deleted(
+    admin_client: TestClient, lang_id: int
+):
+    response = admin_client.delete(f"/admin/languages/{lang_id}")
+    assert response.status_code == 400
+
+
+def test_delete_language_invalid_language_id(admin_client: TestClient):
+    response = admin_client.delete("/admin/languages/67")
+    assert response.status_code == 404
 
 
 def test_update_i18n(admin_client: TestClient, static_dir: pathlib.Path):


### PR DESCRIPTION
- ensures the languages database always contains the rows
  - 1 de
  - 2 en
- don't allow admins to delete either of these languages
  - no use case where this would be required
  - and could make a mess in production if it happened by accident
- remove delete button from admin interface for these languages
- resolves #126