### PR TITLE
Limit allowed file size to 2MB for image uploads

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -8,7 +8,7 @@ server {
         ssl_certificate_key  /mondey_ssl_key.pem;
 
         # Maximum file upload size
-        client_max_body_size 20M;
+        client_max_body_size 2M;
 
         # Improve HTTPS performance with session resumption
         ssl_session_cache shared:SSL:10m;

--- a/frontend/src/lib/components/Admin/EditMilestoneGroupModal.svelte
+++ b/frontend/src/lib/components/Admin/EditMilestoneGroupModal.svelte
@@ -12,9 +12,9 @@ import {
 import type { MilestoneGroupAdmin } from "$lib/client/types.gen";
 import CancelButton from "$lib/components/Admin/CancelButton.svelte";
 import SaveButton from "$lib/components/Admin/SaveButton.svelte";
+import ImageFileUpload from "$lib/components/DataInput/ImageFileUpload.svelte";
 import {
 	ButtonGroup,
-	Fileupload,
 	InputAddon,
 	Label,
 	Modal,
@@ -37,13 +37,6 @@ onMount(() => {
 		image = milestoneGroupImageUrl(milestoneGroup.id);
 	}
 });
-
-function updateImageToUpload(event: Event) {
-	const target = event.target as HTMLInputElement;
-	if (target.files && target.files.length > 0) {
-		image = URL.createObjectURL(target.files[0]);
-	}
-}
 
 async function reloadImg(url: string) {
 	await fetch(url, { cache: "reload", mode: "no-cors" });
@@ -95,12 +88,9 @@ export async function saveChanges() {
 			<Label for="img_upload" class="pb-2">{$_('admin.image')}</Label>
 			<div class="flex flex-row">
 				<img src={image} width="48" height="48" alt="MilestoneGroup" class="mx-2" />
-				<Fileupload
+				<ImageFileUpload
 					bind:files
-					onchange={updateImageToUpload}
-					accept=".jpg, .jpeg, .png"
-					id="img_upload"
-					class="mb-2 flex-grow-0"
+					bind:image
 				/>
 			</div>
 		</div>

--- a/frontend/src/lib/components/Admin/EditMilestoneGroupModal.svelte
+++ b/frontend/src/lib/components/Admin/EditMilestoneGroupModal.svelte
@@ -68,7 +68,7 @@ export async function saveChanges() {
 }
 </script>
 
-<Modal title={$_('admin.edit')} bind:open autoclose size="xl">
+<Modal title={$_('admin.edit')} bind:open outsideclose size="xl">
 	{#if milestoneGroup}
 		{#each textKeys as textKey}
 			{@const title = $_(`admin.${textKey}`)}
@@ -96,7 +96,7 @@ export async function saveChanges() {
 		</div>
 	{/if}
 	<svelte:fragment slot="footer">
-		<SaveButton onclick={saveChanges} />
-		<CancelButton />
+		<SaveButton onclick={() => {open = false; saveChanges()}}/>
+		<CancelButton onclick={() => {open = false;}}/>
 	</svelte:fragment>
 </Modal>

--- a/frontend/src/lib/components/Admin/EditMilestoneModal.svelte
+++ b/frontend/src/lib/components/Admin/EditMilestoneModal.svelte
@@ -13,10 +13,10 @@ import DeleteModal from "$lib/components/Admin/DeleteModal.svelte";
 import EditImage from "$lib/components/Admin/EditImage.svelte";
 import MilestoneExpectedAgeModal from "$lib/components/Admin/MilestoneExpectedAgeModal.svelte";
 import SaveButton from "$lib/components/Admin/SaveButton.svelte";
+import ImageFileUpload from "$lib/components/DataInput/ImageFileUpload.svelte";
 import {
 	Button,
 	ButtonGroup,
-	Fileupload,
 	InputAddon,
 	Label,
 	Modal,
@@ -36,15 +36,6 @@ let showDeleteMilestoneImageModal: boolean = $state(false);
 let showMilestoneExpectedAgeModal: boolean = $state(false);
 
 const textKeys = ["title", "desc", "obs", "help"];
-
-function updateImagesToUpload(event: Event) {
-	const target = event.target as HTMLInputElement;
-	if (target.files) {
-		images = Array.from(target.files).map((f) => URL.createObjectURL(f));
-	} else {
-		images = [];
-	}
-}
 
 async function saveChanges() {
 	if (!milestone) {
@@ -67,7 +58,7 @@ async function saveChanges() {
 }
 
 async function deleteMilestoneImageAndUpdate() {
-	if (!currentMilestoneImageId) {
+	if (!milestone || !currentMilestoneImageId) {
 		return;
 	}
 	const { data, error } = await deleteMilestoneImage({
@@ -121,14 +112,7 @@ async function deleteMilestoneImageAndUpdate() {
                     <img src={image} width="96" height="96" alt="milestone" class="w-24 h-24 m-2"/>
                 {/each}
             </div>
-            <Fileupload
-                    bind:files
-                    on:change={updateImagesToUpload}
-                    multiple
-                    accept=".jpg, .jpeg, .png"
-                    id="img_upload"
-                    class="mb-2 flex-grow-0"
-            />
+            <ImageFileUpload bind:files bind:images multiple></ImageFileUpload>
         </div>
     {/if}
     <svelte:fragment slot="footer">
@@ -140,6 +124,8 @@ async function deleteMilestoneImageAndUpdate() {
 <DeleteModal bind:open={showDeleteMilestoneImageModal} onclick={deleteMilestoneImageAndUpdate}></DeleteModal>
 
 {#key milestone}
+    {#if milestone}
     <MilestoneExpectedAgeModal bind:open={showMilestoneExpectedAgeModal}
-                               milestoneId={milestone?.id}></MilestoneExpectedAgeModal>
+                               milestoneId={milestone.id}></MilestoneExpectedAgeModal>
+    {/if}
 {/key}

--- a/frontend/src/lib/components/DataInput/ImageFileUpload.svelte
+++ b/frontend/src/lib/components/DataInput/ImageFileUpload.svelte
@@ -1,0 +1,52 @@
+<svelte:options runes={true} />
+
+<script lang="ts">
+import WarningModal from "$lib/components/WarningModal.svelte";
+import { Fileupload } from "flowbite-svelte";
+import { _ } from "svelte-i18n";
+
+let {
+	files = $bindable(undefined),
+	images = $bindable([]),
+	image = $bindable(""),
+	...rest
+}: {
+	files: undefined | FileList;
+	images?: Array<string>;
+	image?: string;
+} = $props();
+let showWarningModal: boolean = $state(false);
+
+function isImageFileTooLarge(file: Blob | File): boolean {
+	const maxFileSizeBytes = 2 * 1024 * 1024;
+	return file.size > maxFileSizeBytes;
+}
+
+function updateImagesToUpload(event: Event) {
+	image = "";
+	images = [];
+	const target = event.target as HTMLInputElement;
+	if (target.files) {
+		for (const file of target.files) {
+			if (isImageFileTooLarge(file)) {
+				showWarningModal = true;
+				files = undefined;
+				return;
+			}
+		}
+		images = Array.from(target.files).map((f) => URL.createObjectURL(f));
+		image = images?.[0];
+	}
+}
+</script>
+
+<Fileupload
+		bind:files
+		on:change={updateImagesToUpload}
+		accept=".jpg, .jpeg, .png"
+		class="mb-2 flex-grow-0"
+		{...rest}
+/>
+
+<WarningModal bind:open={showWarningModal}
+			  text={`${$_("admin.max-file-size-is")} 2 MB`}></WarningModal>

--- a/frontend/src/lib/components/DataInput/ImageFileUpload.svelte
+++ b/frontend/src/lib/components/DataInput/ImageFileUpload.svelte
@@ -47,6 +47,5 @@ function updateImagesToUpload(event: Event) {
 		class="mb-2 flex-grow-0"
 		{...rest}
 />
-
 <WarningModal bind:open={showWarningModal}
 			  text={`${$_("admin.max-file-size-is")} 2 MB`}></WarningModal>

--- a/frontend/src/lib/components/WarningModal.svelte
+++ b/frontend/src/lib/components/WarningModal.svelte
@@ -9,7 +9,7 @@ let { open = $bindable(false), text }: { open: boolean; text: string } =
 	$props();
 </script>
 
-<Modal bind:open size="xs" autoclose>
+<Modal bind:open size="xs" autoclose outsideclose>
 	<div class="text-center">
 		<ExclamationCircleOutline class="mx-auto mb-4 h-12 w-12 text-gray-400 dark:text-gray-200" />
 		<h3 class="mb-5 text-lg font-normal text-gray-500 dark:text-gray-400">

--- a/frontend/src/lib/components/WarningModal.svelte
+++ b/frontend/src/lib/components/WarningModal.svelte
@@ -1,0 +1,20 @@
+<svelte:options runes={true} />
+
+<script lang="ts">
+import { Button, Modal } from "flowbite-svelte";
+import ExclamationCircleOutline from "flowbite-svelte-icons/ExclamationCircleOutline.svelte";
+import { _ } from "svelte-i18n";
+
+let { open = $bindable(false), text }: { open: boolean; text: string } =
+	$props();
+</script>
+
+<Modal bind:open size="xs" autoclose>
+	<div class="text-center">
+		<ExclamationCircleOutline class="mx-auto mb-4 h-12 w-12 text-gray-400 dark:text-gray-200" />
+		<h3 class="mb-5 text-lg font-normal text-gray-500 dark:text-gray-400">
+			{text}
+		</h3>
+		<Button color="alternative">{$_('misc.understood')}</Button>
+	</div>
+</Modal>

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -71,7 +71,8 @@
 		"recalculate-expected-age": "Voraussichtliches Alter neu berechnen",
 		"new-expected-age": "Neues Voraussichtliches Alter",
 		"editUserQuestionTitle": "Frage an Benutzer editieren",
-		"expected-age-data": "Voraussichtliches Alter Daten"
+		"expected-age-data": "Voraussichtliches Alter Daten",
+		"max-file-size-is": "Die maximale Dateigröße für ein Bild beträgt"
 	},
 	"researcher": {
 		"label": "Wissenschaft",
@@ -119,7 +120,6 @@
 		"profileAccess": "Ihr Profil",
 		"registerNew": "Als neuer Benutzer registrieren"
 	},
-
 	"userData": {
 		"label": "Persönliche Daten",
 		"heading": "Benutzerdaten eingeben",


### PR DESCRIPTION
- admin-frontend
  - limit upload image file sizes to 2 MB for Milestone and MilestoneGroup images
    - display warning modal and ignore files if too large
- frontend
  - add WarningModal and ImageFileUpload components
- deployment
  - set client_max_body_size to 2MB in nginx config
- backend
  - remove exif orientation tag if present to avoid unexpected rotation of uploaded images in some cases
  - use ImageOps.contain instead of resizing the image
- resolves #165