### PR TITLE
Add `parents=True` to mkdir calls in backend

### DIFF
--- a/mondey_backend/src/mondey_backend/routers/admin_routers/languages.py
+++ b/mondey_backend/src/mondey_backend/routers/admin_routers/languages.py
@@ -40,7 +40,7 @@ def create_router() -> APIRouter:
     ):
         language = get(session, Language, language_id)
         i18json_path = i18n_language_path(language.id)
-        i18json_path.parent.mkdir(exist_ok=True)
+        i18json_path.parent.mkdir(parents=True, exist_ok=True)
         with open(i18json_path, "w", encoding="utf-8") as i18json_file:
             json.dump(i18dict, i18json_file, separators=(",", ":"), ensure_ascii=False)
         return {"ok": True}

--- a/mondey_backend/src/mondey_backend/routers/utils.py
+++ b/mondey_backend/src/mondey_backend/routers/utils.py
@@ -49,7 +49,7 @@ def write_image_file(file: UploadFile, filename: pathlib.Path | str):
     image_max_height = 1024
     image_quality = 90
     try:
-        pathlib.Path(filename).parent.mkdir(exist_ok=True)
+        pathlib.Path(filename).parent.mkdir(parents=True, exist_ok=True)
         with Image.open(file.file) as img:
             # remove EXIF Orientation tag if present
             ImageOps.exif_transpose(img, in_place=True)


### PR DESCRIPTION
- if parent dir is missing it is now created instead of raising an error
- resolves #180