### PR TITLE
Make flaky test robust

### DIFF
--- a/mondey_backend/pyproject.toml
+++ b/mondey_backend/pyproject.toml
@@ -21,6 +21,8 @@ dependencies = [
     "click",
     "pillow",
     "webp",
+    "python-dateutil",
+    "types-python-dateutil"
 ]
 dynamic = ["version"]
 

--- a/mondey_backend/tests/conftest.py
+++ b/mondey_backend/tests/conftest.py
@@ -5,6 +5,7 @@ import pathlib
 
 import pytest
 import pytest_asyncio
+from dateutil.relativedelta import relativedelta  # type: ignore
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from PIL import Image
@@ -79,8 +80,14 @@ def private_dir(tmp_path_factory: pytest.TempPathFactory):
 @pytest.fixture
 def children():
     today = datetime.datetime.today()
-    nine_months_ago = today - datetime.timedelta(days=9 * 30)
-    twenty_months_ago = today - datetime.timedelta(days=20 * 30)
+
+    # README: this is not entirel stable for all dates. For example, for
+    # 26th november = today, nine-months ago give 1st March, which then gives
+    # you 8 months instead of 9 if done as today - datetime.timedelta(days=9 * 30)
+    # Hence: use dateutil.relativedelta which takes care of the 31 vs 30 vs 28 days stuff
+    nine_months_ago = today - relativedelta(months=9)  # type: ignore
+    twenty_months_ago = today - relativedelta(months=20)  # type: ignore
+
     return [
         # ~9month old child for user (id 3)
         {

--- a/mondey_backend/tests/routers/admin_routers/test_admin_milestones.py
+++ b/mondey_backend/tests/routers/admin_routers/test_admin_milestones.py
@@ -230,18 +230,11 @@ def test_get_milestone_age_scores(admin_client: TestClient):
     # child 1 scored
     #   - 2 @ ~8 months old
     #   - 4 @ ~9 months old
-    expected_age = response.json()["expected_age"]
-    assert 8 <= expected_age <= 10
-    assert response.json()["scores"][expected_age - 2]["avg_score"] == pytest.approx(
-        0.0
-    )
-    assert response.json()["scores"][expected_age - 1]["avg_score"] == pytest.approx(
-        2.0
-    )
-    assert response.json()["scores"][expected_age]["avg_score"] == pytest.approx(4.0)
-    assert response.json()["scores"][expected_age + 1]["avg_score"] == pytest.approx(
-        0.0
-    )
+    assert response.json()["expected_age"] == 9
+    assert response.json()["scores"][7]["avg_score"] == pytest.approx(0.0)
+    assert response.json()["scores"][8]["avg_score"] == pytest.approx(2.0)
+    assert response.json()["scores"][9]["avg_score"] == pytest.approx(4.0)
+    assert response.json()["scores"][10]["avg_score"] == pytest.approx(0.0)
 
 
 def test_get_submitted_milestone_images(admin_client: TestClient):

--- a/mondey_backend/tests/routers/admin_routers/test_admin_milestones.py
+++ b/mondey_backend/tests/routers/admin_routers/test_admin_milestones.py
@@ -230,11 +230,18 @@ def test_get_milestone_age_scores(admin_client: TestClient):
     # child 1 scored
     #   - 2 @ ~8 months old
     #   - 4 @ ~9 months old
-    assert response.json()["expected_age"] == 9
-    assert response.json()["scores"][7]["avg_score"] == pytest.approx(0.0)
-    assert response.json()["scores"][8]["avg_score"] == pytest.approx(2.0)
-    assert response.json()["scores"][9]["avg_score"] == pytest.approx(4.0)
-    assert response.json()["scores"][10]["avg_score"] == pytest.approx(0.0)
+    expected_age = response.json()["expected_age"]
+    assert 8 <= expected_age <= 10
+    assert response.json()["scores"][expected_age - 2]["avg_score"] == pytest.approx(
+        0.0
+    )
+    assert response.json()["scores"][expected_age - 1]["avg_score"] == pytest.approx(
+        2.0
+    )
+    assert response.json()["scores"][expected_age]["avg_score"] == pytest.approx(4.0)
+    assert response.json()["scores"][expected_age + 1]["avg_score"] == pytest.approx(
+        0.0
+    )
 
 
 def test_get_submitted_milestone_images(admin_client: TestClient):


### PR DESCRIPTION
- expected age can vary by +/- 1 month depending on exact date when test runs
- this is due to making the answer session 30 days in the past, which is not always the previous month
- allow for this in the test so the test is valid regardless of the current date!