### PR TITLE
Fix the set of milestones when a milestone answer session is created

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     rev: v1.13.0
     hooks:
       - id: mypy
-        additional_dependencies: ["sqlmodel"]
+        additional_dependencies: ["sqlmodel", "types-python-dateutil"]
         args:
           [
             --ignore-missing-imports,

--- a/frontend/src/lib/components/Milestone.svelte
+++ b/frontend/src/lib/components/Milestone.svelte
@@ -255,7 +255,7 @@ const breadcrumbdata = $derived([
 					</Button>
 					<Button
 						color="light"
-						disabled={selectedAnswer === undefined}
+						disabled={!selectedAnswer || selectedAnswer < 0}
 						on:click={nextMilestone}
 						class="m-1 mt-4 text-gray-700 dark:text-gray-400"
 					>

--- a/mondey_backend/src/mondey_backend/models/milestones.py
+++ b/mondey_backend/src/mondey_backend/models/milestones.py
@@ -163,6 +163,7 @@ class MilestoneAnswer(SQLModel, table=True):
     milestone_id: int | None = Field(
         default=None, foreign_key="milestone.id", primary_key=True
     )
+    milestone_group_id: int = Field(default=None, foreign_key="milestonegroup.id")
     answer: int
 
 

--- a/mondey_backend/src/mondey_backend/routers/milestones.py
+++ b/mondey_backend/src/mondey_backend/routers/milestones.py
@@ -16,8 +16,8 @@ from ..models.milestones import MilestonePublic
 from ..models.milestones import SubmittedMilestoneImage
 from .utils import add
 from .utils import get
-from .utils import get_child_age_in_months
 from .utils import get_db_child
+from .utils import get_or_create_current_milestone_answer_session
 from .utils import submitted_milestone_image_path
 from .utils import write_image_file
 
@@ -52,25 +52,18 @@ def create_router() -> APIRouter:
         current_active_user: CurrentActiveUserDep,
         child_id: int,
     ):
-        delta_months = 6
         child = get_db_child(session, current_active_user, child_id)
-
-        child_age_months = get_child_age_in_months(child)
+        milestone_answer_session = get_or_create_current_milestone_answer_session(
+            session, current_active_user, child
+        )
+        milestone_ids = list(milestone_answer_session.answers.keys())
+        print("milestone_ids", milestone_ids)
         milestone_groups = session.exec(
             select(MilestoneGroup)
             .order_by(col(MilestoneGroup.order))
             .options(
                 lazyload(
-                    MilestoneGroup.milestones.and_(
-                        (
-                            child_age_months
-                            >= col(Milestone.expected_age_months) - delta_months
-                        )
-                        & (
-                            child_age_months
-                            <= col(Milestone.expected_age_months) + delta_months
-                        )
-                    )
+                    MilestoneGroup.milestones.and_(col(Milestone.id).in_(milestone_ids))
                 )
             )
         ).all()

--- a/mondey_backend/src/mondey_backend/routers/users.py
+++ b/mondey_backend/src/mondey_backend/routers/users.py
@@ -12,7 +12,6 @@ from ..dependencies import SessionDep
 from ..models.children import Child
 from ..models.children import ChildCreate
 from ..models.children import ChildPublic
-from ..models.milestones import MilestoneAnswer
 from ..models.milestones import MilestoneAnswerPublic
 from ..models.milestones import MilestoneAnswerSession
 from ..models.milestones import MilestoneAnswerSessionPublic
@@ -124,8 +123,9 @@ def create_router() -> APIRouter:
     def get_current_milestone_answer_session(
         session: SessionDep, current_active_user: CurrentActiveUserDep, child_id: int
     ):
+        child = get_db_child(session, current_active_user, child_id)
         milestone_answer_session = get_or_create_current_milestone_answer_session(
-            session, current_active_user, child_id
+            session, current_active_user, child
         )
         return milestone_answer_session
 
@@ -146,15 +146,9 @@ def create_router() -> APIRouter:
             raise HTTPException(401)
         milestone_answer = milestone_answer_session.answers.get(answer.milestone_id)
         if milestone_answer is None:
-            milestone_answer = MilestoneAnswer(
-                answer_session_id=milestone_answer_session.id,
-                milestone_id=answer.milestone_id,
-                answer=answer.answer,
-            )
-            add(session, milestone_answer)
-        else:
-            milestone_answer.answer = answer.answer
-            session.commit()
+            raise HTTPException(401)
+        milestone_answer.answer = answer.answer
+        session.commit()
         return milestone_answer
 
     # Endpoints for answers to user question

--- a/mondey_backend/src/mondey_backend/routers/utils.py
+++ b/mondey_backend/src/mondey_backend/routers/utils.py
@@ -139,26 +139,44 @@ def _session_has_expired(milestone_answer_session: MilestoneAnswerSession) -> bo
 
 
 def get_or_create_current_milestone_answer_session(
-    session: SessionDep, current_active_user: User, child_id: int
+    session: SessionDep, current_active_user: User, child: Child
 ) -> MilestoneAnswerSession:
-    get_db_child(session, current_active_user, child_id)
     milestone_answer_session = session.exec(
         select(MilestoneAnswerSession)
-        .where(
-            (col(MilestoneAnswerSession.user_id) == current_active_user.id)
-            & (col(MilestoneAnswerSession.child_id) == child_id)
-        )
+        .where(col(MilestoneAnswerSession.user_id) == current_active_user.id)
+        .where(col(MilestoneAnswerSession.child_id) == child.id)
         .order_by(col(MilestoneAnswerSession.created_at).desc())
     ).first()
     if milestone_answer_session is None or _session_has_expired(
         milestone_answer_session
     ):
         milestone_answer_session = MilestoneAnswerSession(
-            child_id=child_id,
+            child_id=child.id,
             user_id=current_active_user.id,
             created_at=datetime.datetime.now(),
         )
         add(session, milestone_answer_session)
+        delta_months = 6
+        child_age_months = get_child_age_in_months(child)
+        milestones = session.exec(
+            select(Milestone)
+            .where(
+                child_age_months >= col(Milestone.expected_age_months) - delta_months
+            )
+            .where(
+                child_age_months <= col(Milestone.expected_age_months) + delta_months
+            )
+        ).all()
+        for milestone in milestones:
+            session.add(
+                MilestoneAnswer(
+                    answer_session_id=milestone_answer_session.id,
+                    milestone_id=milestone.id,
+                    milestone_group_id=milestone.group_id,
+                    answer=-1,
+                )
+            )
+        session.commit()
     return milestone_answer_session
 
 

--- a/mondey_backend/tests/conftest.py
+++ b/mondey_backend/tests/conftest.py
@@ -5,7 +5,7 @@ import pathlib
 
 import pytest
 import pytest_asyncio
-from dateutil.relativedelta import relativedelta  # type: ignore
+from dateutil.relativedelta import relativedelta
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from PIL import Image
@@ -81,12 +81,8 @@ def private_dir(tmp_path_factory: pytest.TempPathFactory):
 def children():
     today = datetime.datetime.today()
 
-    # README: this is not entirel stable for all dates. For example, for
-    # 26th november = today, nine-months ago give 1st March, which then gives
-    # you 8 months instead of 9 if done as today - datetime.timedelta(days=9 * 30)
-    # Hence: use dateutil.relativedelta which takes care of the 31 vs 30 vs 28 days stuff
-    nine_months_ago = today - relativedelta(months=9)  # type: ignore
-    twenty_months_ago = today - relativedelta(months=20)  # type: ignore
+    nine_months_ago = today - relativedelta(months=9)
+    twenty_months_ago = today - relativedelta(months=20)
 
     return [
         # ~9month old child for user (id 3)
@@ -235,13 +231,29 @@ def session(children: list[dict]):
                 ),
             )
         )
-        session.add(MilestoneAnswer(answer_session_id=1, milestone_id=1, answer=1))
-        session.add(MilestoneAnswer(answer_session_id=1, milestone_id=2, answer=0))
+        session.add(
+            MilestoneAnswer(
+                answer_session_id=1, milestone_id=1, milestone_group_id=1, answer=1
+            )
+        )
+        session.add(
+            MilestoneAnswer(
+                answer_session_id=1, milestone_id=2, milestone_group_id=1, answer=0
+            )
+        )
         # add another (current) milestone answer session for child 1 / user (id 3) with 2 answers to the same questions
         session.add(MilestoneAnswerSession(child_id=1, user_id=3, created_at=today))
         # add two milestone answers
-        session.add(MilestoneAnswer(answer_session_id=2, milestone_id=1, answer=3))
-        session.add(MilestoneAnswer(answer_session_id=2, milestone_id=2, answer=2))
+        session.add(
+            MilestoneAnswer(
+                answer_session_id=2, milestone_id=1, milestone_group_id=1, answer=3
+            )
+        )
+        session.add(
+            MilestoneAnswer(
+                answer_session_id=2, milestone_id=2, milestone_group_id=1, answer=2
+            )
+        )
         # add an (expired) milestone answer session for child 3 / admin user (id 1) with 1 answer
         session.add(
             MilestoneAnswerSession(
@@ -250,7 +262,11 @@ def session(children: list[dict]):
                 created_at=datetime.datetime(today.year - 1, 1, 1),
             )
         )
-        session.add(MilestoneAnswer(answer_session_id=3, milestone_id=7, answer=2))
+        session.add(
+            MilestoneAnswer(
+                answer_session_id=3, milestone_id=7, milestone_group_id=2, answer=2
+            )
+        )
 
         # add user questions for admin
         user_questions = [

--- a/mondey_backend/tests/routers/test_users.py
+++ b/mondey_backend/tests/routers/test_users.py
@@ -183,22 +183,21 @@ def test_get_milestone_answers_child1_current_answer_session(user_client: TestCl
     assert _is_approx_now(response.json()["created_at"])
 
 
-def test_update_milestone_answer_current_answer_session_no_answer_session(
+def test_update_milestone_answer_no_current_answer_session(
     user_client: TestClient,
 ):
-    current_answer_session = user_client.get("/users/milestone-answers/1").json()
-    assert current_answer_session["child_id"] == 1
-    assert "6" not in current_answer_session["answers"]
-    new_answer = {"milestone_id": 6, "answer": 2}
+    current_answer_session = user_client.get("/users/milestone-answers/2").json()
+    assert current_answer_session["child_id"] == 2
+    assert current_answer_session["answers"]["3"]["answer"] == -1
+    assert current_answer_session["answers"]["4"]["answer"] == -1
+    new_answer = {"milestone_id": 3, "answer": 2}
     response = user_client.put(
         f"/users/milestone-answers/{current_answer_session['id']}", json=new_answer
     )
     assert response.status_code == 200
     assert response.json() == new_answer
-    assert (
-        user_client.get("/users/milestone-answers/1").json()["answers"]["6"]
-        == new_answer
-    )
+    new_answer_session = user_client.get("/users/milestone-answers/2").json()
+    assert new_answer_session["answers"]["3"] == new_answer
 
 
 def test_update_milestone_answer_update_existing_answer(user_client: TestClient):


### PR DESCRIPTION
- MilestoneAnswer
  - An answer is now created for every milestone when an answer session is created
  - The initial value of the answer is `-1` which indicates the user has not yet submitted an answer for this milestone
  - Add `milestone_group_id` field for convenience when calculating statistics / feedback
- get_milestone_groups
  - Now returns the milestones according to the MilestoneAnswers for the current session
  - This means the set of milestones is fixed and doesn't change even if a milestone expected_age changes such that it would no longer be selected for that session
- update_milestone_answer
  - no longer creates an answer session if there is no existing unexpired one
  - either updates the existing answer for the supplied session, or returns 404 or 401
- Milestone component
  - all answers now exist, replace check for existence with check for `-1` to determine if the answer has already been answered
- add types-python-dateutil to mypy pre-commit hook dependencies
  - remove out-dated comment & type ignores from related code
- resolves #189