### PR TITLE
Allow certbot to renew SSL certificates without stopping frontend

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -5,30 +5,46 @@ Some information on how to deploy the website - currently it is deployed on a te
 ## Production deployment
 
 Production docker container images are automatically built by CI.
+Before running them, the location of the data directory, SSL keys and secret key should be set
+either in env vars or in a file `.env` in the same location as the docker compose.yml.
+
+For example the current test deployment on heicloud looks like this:
+
+```
+MONDEY_SSL_CERT="/etc/letsencrypt/live/mondey.lkeegan.dev/fullchain.pem"
+MONDEY_SSL_KEY="/etc/letsencrypt/live/mondey.lkeegan.dev/privkey.pem"
+```
+
+### docker compose
+
 To deploy the latest version on a virtual machine with docker compose installed,
 download [docker-compose.yml](https://raw.githubusercontent.com/ssciwr/mondey/main/docker-compose.yml), then do
 
 ```
-sudo docker compose pull
-sudo docker compose up -d
+sudo docker compose pull && sudo docker compose up -d && sudo docker system prune -af
 ```
 
-The location of the database directory, image files directory, SSL keys and secret key should be set
-either in env vars or in a file `.env` in the same location as the docker-compose.yml.
+The same command can be used to update the running website to use the latest available docker images.
 
-TODO: document these options
-
-The current status of the containers can be checked with
+The current status of the running containers can be checked with
 
 ```
 sudo docker compose ps
 sudo docker compose logs
 ```
 
-To update the running website to the latest version:
+### SSL certificates
+
+To generate SSL certificates for the domain `mondey.lkeegan.dev` from [Let's Encrypt](https://letsencrypt.org/) using [Certbot](https://certbot.eff.org/):
 
 ```
-sudo docker compose pull && sudo docker compose up -d && sudo docker system prune -af
+sudo docker run -it --rm -v/etc/letsencrypt:/etc/letsencrypt -v/var/www/certbot:/var/www/certbot certbot/certbot certonly --webroot --webroot-path /var/www/certbot/ -n -d mondey.lkeegan.dev
+```
+
+The certificates needs renewing every three months, which can be done manually using the same command. To automatically renew once a week you can use cron, e.g. `sudo crontab -e`, then add the following line:
+
+```
+0 0 * * 0 docker run -it --rm -v/etc/letsencrypt:/etc/letsencrypt -v/var/www/certbot:/var/www/certbot certbot/certbot certonly --webroot --webroot-path /var/www/certbot/ -n -d mondey.lkeegan.dev
 ```
 
 ### Give users admin rights

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,11 @@ services:
       - PORT=${PORT:-80}
       - RELOAD=${RELOAD:-false}
       - LOG_LEVEL=${LOG_LEVEL:-info}
+    logging:
+      driver: "local"
+      options:
+        max-size: 20m
+        max-file: 25
   frontend:
     image: ghcr.io/ssciwr/mondey_frontend:${MONDEY_DOCKER_IMAGE_TAG:-latest}
     build:
@@ -28,7 +33,19 @@ services:
     volumes:
       - ${MONDEY_SSL_CERT:-./cert.pem}:/mondey_ssl_cert.pem
       - ${MONDEY_SSL_KEY:-./key.pem}:/mondey_ssl_key.pem
+      # to allow certbot to renew SSL certificates:
+      - /var/www/certbot:/var/www/certbot:ro
+    logging:
+      driver: "local"
+      options:
+        max-size: 20m
+        max-file: 25
   email:
     image: "boky/postfix"
     environment:
       - ALLOW_EMPTY_SENDER_DOMAINS="true"
+    logging:
+      driver: "local"
+      options:
+        max-size: 20m
+        max-file: 3

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,9 +1,33 @@
 server {
+    # allow certbot to renew SSL certificates using port 80
+    listen 80;
+    listen [::]:80;
+
+    server_name mondey.lkeegan.dev;
+    server_tokens off;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    # forward anything else to https://mondey.lkeegan.dev
+    location / {
+        return 301 https://mondey.lkeegan.dev$request_uri;
+    }
+}
+
+server {
+    # redirect www.mondey.lkeegan to mondey.lkeegan.dev
+    server_name www.mondey.lkeegan.dev;
+    return 301 $scheme://mondey.lkeegan.dev$request_uri;
+}
+
+server {
    listen 80;
    listen 443 ssl;
    listen [::]:443 ssl;
    http2 on;
-   server_name www.mondey.lkeegan.dev mondey.lkeegan.dev localhost;
+   server_name mondey.lkeegan.dev;
         ssl_certificate      /mondey_ssl_cert.pem;
         ssl_certificate_key  /mondey_ssl_key.pem;
 


### PR DESCRIPTION
- update nginx.conf
  - allow certbot certificate renewal on port 80
  - forward everything else to https://mondey.lkeegan.dev
- update docker-compose
  - mount a folder to allow certbot to renew SSL certificates
  - add better default logging settings
- update deployment docs
  - add command to generate / renew SSL certificates & sample crontab entry