### PR TITLE
Fix crontab startup issue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - PORT=${PORT:-80}
       - RELOAD=${RELOAD:-false}
       - LOG_LEVEL=${LOG_LEVEL:-info}
-      - STATS_CRONTAB=${STATS_CRONTAB:-"0 3 * * mon"}
+      - STATS_CRONTAB=${STATS_CRONTAB:-0 3 * * mon}
     logging:
       driver: "local"
       options:

--- a/mondey_backend/src/mondey_backend/main.py
+++ b/mondey_backend/src/mondey_backend/main.py
@@ -33,11 +33,9 @@ async def lifespan(app: FastAPI):
     create_mondey_db_and_tables()
     await create_user_db_and_tables()
     scheduler = AsyncIOScheduler()
-    cronexpr = app_settings.STATS_CRONTAB.replace('\"','\'').replace('mon', '1')
-    print(f'crontab shit: {app_settings.STATS_CRONTAB}')
     scheduler.add_job(
         scheduled_update_stats,
-        CronTrigger.from_crontab(cronexpr),
+        CronTrigger.from_crontab(app_settings.STATS_CRONTAB),
     )
     scheduler.start()
     yield

--- a/mondey_backend/src/mondey_backend/main.py
+++ b/mondey_backend/src/mondey_backend/main.py
@@ -33,8 +33,8 @@ async def lifespan(app: FastAPI):
     create_mondey_db_and_tables()
     await create_user_db_and_tables()
     scheduler = AsyncIOScheduler()
-    print(f'crontab shit: {app_settings.STATS_CRONTAB}')
     cronexpr = app_settings.STATS_CRONTAB.replace('\"','\'').replace('mon', '1')
+    print(f'crontab shit: {app_settings.STATS_CRONTAB}')
     scheduler.add_job(
         scheduled_update_stats,
         CronTrigger.from_crontab(cronexpr),

--- a/mondey_backend/src/mondey_backend/main.py
+++ b/mondey_backend/src/mondey_backend/main.py
@@ -33,9 +33,11 @@ async def lifespan(app: FastAPI):
     create_mondey_db_and_tables()
     await create_user_db_and_tables()
     scheduler = AsyncIOScheduler()
+    print(f'crontab shit: {app_settings.STATS_CRONTAB}')
+    cronexpr = app_settings.STATS_CRONTAB.replace('\"','\'').replace('mon', '1')
     scheduler.add_job(
         scheduled_update_stats,
-        CronTrigger.from_crontab(app_settings.STATS_CRONTAB),
+        CronTrigger.from_crontab(cronexpr),
     )
     scheduler.start()
     yield


### PR DESCRIPTION
- remove additional quotes in the docker compose file to make sure the backend starts correctly