### PR TITLE
Update DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -84,14 +84,3 @@ pnpm run dev
 ```
 
 The website is then served at http://localhost:5173/.
-
-3.2: If you encounter CORS/login/API connection from frontend issues, do the below: Implement this CORS workaround so your frontend and backend requests connect after login (if you see HTTP 401 or "Unauthorised", it could be CORS)
-
-3.2.1: Add the below code to `vite.config.ts` in the existing 'server' section after "strictPort: true":
-```
-proxy: {
-			'/api': 'http://localhost:8000',
-		},
-```
-
-3.2.2: And set `VITE_MONDEY_API_URL=http://localhost:5173/api` in `/frontend/.env`

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -66,7 +66,7 @@ cd mondey
 
 ```sh
 cd mondey_backend
-pip install .
+pip install -e .
 cd ..
 mondey-backend
 ```


### PR DESCRIPTION
(Remove unnecessary workaround info)

@lkeegan I also wanted to check if it make sense to change `pip install .` to `pip install -e ` in the python install docs?

Only because with the former, the mondey_backend module runs with whatever the code was when first installing, with -e, it will change for the backend when users run 'mondey-backend' (Though I have the feeling I'm missing an easier way to do that)

But I haven't done as much Python recently so I'm not totally sure that's sensible. It just got editing backend python code to work for me just now.