### PR TITLE
Admin page translations use frontend de values if missing or empty

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -60,3 +60,14 @@ sqlite3 db/users.db
 sqlite> UPDATE user SET is_superuser = 1 WHERE email = 'user@domain.com';
 sqlite> .quit
 ```
+
+### Internationalization
+
+All text on the website is translated into multiple languages, and the translations can be edited from the admin interface.
+In the frontend code, all user-facing text is defined (with placeholder german texts) in [frontend/src/lib/translations.ts](https://github.com/ssciwr/mondey/blob/main/frontend/src/lib/translations.ts).
+When the website is loaded by a user, the translations that were made in the admin interface for all of these texts are downloaded from the server.
+
+_Note: When new text is added to [frontend/src/lib/translations.ts](https://github.com/ssciwr/mondey/blob/main/frontend/src/lib/translations.ts),
+and the deployed website has been updated,
+the translations for this new text need to entered using the admin interface.
+Until this is done the new text will not be visible in the deployed website!_

--- a/frontend/src/lib/components/Admin/Translations.svelte
+++ b/frontend/src/lib/components/Admin/Translations.svelte
@@ -41,6 +41,20 @@ async function getTranslations() {
 						data[section_key] = {};
 					}
 				}
+				// use built-in frontend text for any missing / empty entries in de locale json from server
+				if (locale === "de") {
+					for (const [section_key, section] of Object.entries(translationIds)) {
+						for (const [item_key, item] of Object.entries(section)) {
+							if (
+								!(item_key in data[section_key]) ||
+								data[section_key][item_key] === ""
+							) {
+								console.log(section_key, item_key);
+								data[section_key][item_key] = item;
+							}
+						}
+					}
+				}
 				translations[locale] = data;
 			}
 		} catch {


### PR DESCRIPTION
- use frontend de texts if missing or empty in de.json from server
  - previously we would just use an empty string in this case
- document translation in DEPLOYMENT.md
  - i.e. that admin needs to go fill in translations in the admin interface if a new text is added to the frontend code
- resolves #241