### PR TITLE
Standardize tailwind css buttons

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -23,6 +23,10 @@
 		color: #2757ac;
 	}
 
+	.text-muted {
+		color: #838383;
+	}
+
 	.text-base {
 		@apply text-gray-900 dark:text-gray-100;
 	}
@@ -36,11 +40,12 @@
 		min-width: unset;
 		@apply py-2 px-2 rounded-md relative;
 		position: relative;
+		background-color: white !important;
 	}
 
 	/* Button icon group styling */
 	.btn-icon + .btn-icon {
-		margin-left: -8px; /* Negative margin to make borders overlap */
+		margin-left: -10px; /* Negative margin to make borders overlap */
 	}
 
 	/* Remove border radius between adjacent buttons */

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -31,95 +31,42 @@
 		background-color: rgb(124, 158, 157);
 	}
 
-	.bg-text {
-		color: rgb(124, 158, 157);
-	}
-
-	.btn-primary {
-		border: 2px solid rgb(124, 158, 157);
-		@apply btn text-btn bg-primary text-white font-semibold bg-additional-color-600 rounded-lg shadow-md hover:bg-additional-color-700 focus:outline-none focus:ring focus:ring-additional-color-300 focus:ring-opacity-75;
-	}
-
-	.btn-primary:hover {
-		border: 2px solid rgb(124, 158, 157);
-	}
-
-	.bg-special {
-		background-color: rgba(124, 158, 157, 0.15);
-		color: rgba(255, 255, 255, 0.925);
-	}
-
-	.btn-secondary {
-		/* This should be considered the default class to use for buttons */
-		border: 2px solid rgb(124, 158, 157);
-		background-color: #e5f4f4; /* #dbfdfc also good | #e2fbfb; */
-		@apply btn text-btn text-additional-color-700 dark:bg-special font-semibold rounded-lg shadow-md hover:bg-additional-color-700 hover:text-white focus:outline-none focus:ring focus:ring-additional-color-300 focus:ring-opacity-75;
-	}
-	.btn-secondary:hover {
-		background-color: rgb(124, 158, 157);
-		color: white;
-	}
-
-	.btn-danger {
-		border: 2px solid rgb(200, 30, 30);
-		background-color: rgba(200, 30, 30, 0.1);
-		@apply btn text-btn dark:text-white text-red-700 font-semibold rounded-lg shadow-md hover:bg-red-500 hover:text-white focus:outline-none focus:ring focus:ring-red-400 focus:ring-opacity-75;
-	}
-	.btn-danger:hover {
-		border: 2px solid rgb(240, 82, 82);
-		background-color: rgba(200, 30, 30, 0.6);
-	}
+	/* Basic button icon styles */
 	.btn-icon {
 		min-width: unset;
-		@apply btn py-2 px-2; /* Just applies symmetrical vertical/horizontal padding for typically square/round icons */
+		@apply py-2 px-2 rounded-md relative;
+		position: relative;
 	}
 
-	/* For Text content */
-	.h1 {
-		@apply mb-2 mt-4 text-xl font-bold text-gray-700 dark:text-white tracking-wide;
-	}
-	.h2 {
-		@apply mb-1 mt-3 text-xl text-gray-700 dark:text-white tracking-wide;
-	}
-	.h3 {
-		@apply mb-1 mt-2 text-lg   font-bold  text-gray-700 dark:text-white tracking-wide;
-	}
-	.text-muted {
-		@apply mb-5 text-base text-gray-500 dark:text-gray-400;
-	}
-	/* For layout */
-	.panel {
-		background-color: white;
-		border: 1px solid rgb(100, 100, 100);
-		@apply max-w-prose shadow-xl  min-w-full p-6 rounded-xl;
-		/* we use .panel in order not to clash with tailwind/.card classes. */
+	/* Button icon group styling */
+	.btn-icon + .btn-icon {
+		margin-left: -8px; /* Negative margin to make borders overlap */
 	}
 
-	.panel-centered {
-		@apply panel justify-center text-center;
-		/* we use .panel in order not to clash with tailwind/.card classes. */
+	/* Remove border radius between adjacent buttons */
+	.btn-icon:not(:first-child):not(:last-child) {
+		border-radius: 0;
 	}
 
-	/* Custom/other CSS which is app-wide */
-
-	/* Util classes */
-
-	/* For icon alignment with buttons */
-	.btn-primary,
-	.btn-secondary,
-	.btn-primary,
-	.btn-secondary,
-	.btn-danger {
-		@apply inline-flex items-center justify-center gap-2;
+	/* Keep left border radius for first button */
+	.btn-icon:first-child:not(:only-child) {
+		border-top-right-radius: 0;
+		border-bottom-right-radius: 0;
 	}
 
-	/* Make sure icons have consistent vertical alignment */
-	.btn-primary svg,
-	.btn-secondary svg,
-	.btn-primary svg,
-	.btn-secondary svg,
-	.btn-danger svg {
-		@apply inline-block align-middle;
+	/* Keep right border radius for last button */
+	.btn-icon:last-child:not(:only-child) {
+		border-top-left-radius: 0;
+		border-bottom-left-radius: 0;
+	}
+
+	.btn-icon-rounded {
+		border-radius: 0.5rem !important;
+	}
+
+	/* Make sure the button that's being hovered appears on top */
+	.btn-icon:hover {
+		z-index: 1;
 	}
 
 	@media only screen and (min-device-width: 320px) and (max-device-width: 480px) {

--- a/frontend/src/lib/components/Admin/AddButton.svelte
+++ b/frontend/src/lib/components/Admin/AddButton.svelte
@@ -11,6 +11,6 @@ let {
 }: { onclick: (event: Event) => void; disabled?: boolean } = $props();
 </script>
 
-<Button color="blue" {onclick} {disabled}
+<Button class="btn-primary" {onclick} {disabled}
 	><PlusOutline class="me-2 h-5 w-5" /> {i18n.tr.admin.add}</Button
 >

--- a/frontend/src/lib/components/Admin/DeleteButton.svelte
+++ b/frontend/src/lib/components/Admin/DeleteButton.svelte
@@ -8,4 +8,4 @@ import Button from "flowbite-svelte/Button.svelte";
 let { onclick }: { onclick: (event: Event) => void } = $props();
 </script>
 
-<Button color="red" {onclick}><TrashBinOutline class="me-2 h-5 w-5" /> {i18n.tr.admin.delete}</Button>
+<Button class="btn-danger btn-icon" aria-roledescription={i18n.tr.admin.delete} {onclick}><TrashBinOutline class="h-5 w-5" /></Button>

--- a/frontend/src/lib/components/Admin/EditButton.svelte
+++ b/frontend/src/lib/components/Admin/EditButton.svelte
@@ -8,4 +8,4 @@ import Button from "flowbite-svelte/Button.svelte";
 let { onclick }: { onclick: (event: Event) => void } = $props();
 </script>
 
-<Button color="yellow" {onclick}><EditOutline class="me-2 h-5 w-5" /> {i18n.tr.admin.edit}</Button>
+<Button class="btn-secondary btn-icon" aria-roledescription={i18n.tr.admin.edit} {onclick}><EditOutline class="h-5 w-5" /></Button>

--- a/frontend/src/lib/components/Admin/MilestoneExpectedAges.svelte
+++ b/frontend/src/lib/components/Admin/MilestoneExpectedAges.svelte
@@ -89,7 +89,7 @@ async function saveNewExpectedAges() {
     {#if milestoneGroups && i18n.locale}
         <div class="grid grid-cols-2 justify-items-stretch">
             <div class="grid grid-rows-2">
-                <Button class="mx-2" onclick={getNewExpectedAges}>
+                <Button class="btn-primary" onclick={getNewExpectedAges}>
                     <RefreshOutline class="me-2 h-5 w-5"/> {i18n.tr.admin.recalculateExpectedAge}</Button>
                 <div class="m-2">
                     <Progressbar labelInside progress={calculateProgress} size="h-4"/>

--- a/frontend/src/lib/components/Admin/MilestoneGroups.svelte
+++ b/frontend/src/lib/components/Admin/MilestoneGroups.svelte
@@ -224,7 +224,6 @@ async function doDeleteMilestone() {
 											<TableBodyCell></TableBodyCell>
 											<TableBodyCell></TableBodyCell>
 											<TableBodyCell>
-												<AddButton onclick={() => addMilestone(milestoneGroup.id)} />
 												<ReorderButton
 														onclick={(event: Event) => {
 															event.stopPropagation();
@@ -232,6 +231,7 @@ async function doDeleteMilestone() {
 															currentOrderItems = milestoneGroup.milestones.map((milestone) => {return {id: milestone.id, text: milestone.text[i18n.locale]?.title};});
 															showOrderItemsModal = true;
 														}} />
+												<AddButton onclick={() => addMilestone(milestoneGroup.id)} />
 											</TableBodyCell>
 										</TableBodyRow>
 									</TableBody>
@@ -245,7 +245,6 @@ async function doDeleteMilestone() {
 					<TableBodyCell></TableBodyCell>
 					<TableBodyCell></TableBodyCell>
 					<TableBodyCell>
-						<AddButton onclick={addMilestoneGroup} />
 						<ReorderButton
 								onclick={(event: Event) => {
 									event.stopPropagation();
@@ -253,6 +252,7 @@ async function doDeleteMilestone() {
 									currentOrderItems = $milestoneGroups.map((milestoneGroup) => {return {id: milestoneGroup.id, text: milestoneGroup.text[i18n.locale]?.title};});
 									showOrderItemsModal = true;
 								}} />
+						<AddButton onclick={addMilestoneGroup} />
 					</TableBodyCell>
 				</TableBodyRow>
 			</TableBody>

--- a/frontend/src/lib/components/Admin/Questions.svelte
+++ b/frontend/src/lib/components/Admin/Questions.svelte
@@ -116,6 +116,12 @@ onMount(async () => {
 <Card size="xl" class="m-5 w-full">
 	<h3 class="mb-3 text-xl font-medium text-gray-900 dark:text-white">
 		{i18n.tr.admin[`${kind}Questions`]}
+		<ReorderButton
+				onclick={() => {
+							currentOrderItems = $questions.map((question) => {return {id: question.id, text: question.text[i18n.locale]?.question};});
+							showOrderItemsModal = true;
+						}}
+		/>
 	</h3>
 	<Table>
 		<TableHead>
@@ -158,12 +164,6 @@ onMount(async () => {
 				<TableBodyCell></TableBodyCell>
 				<TableBodyCell>
 					<AddButton onclick={addQuestion} />
-					<ReorderButton
-						onclick={() => {
-							currentOrderItems = $questions.map((question) => {return {id: question.id, text: question.text[i18n.locale]?.question};});
-							showOrderItemsModal = true;
-						}}
-					/>
 				</TableBodyCell>
 			</TableBodyRow>
 		</TableBody>

--- a/frontend/src/lib/components/Admin/ReorderButton.svelte
+++ b/frontend/src/lib/components/Admin/ReorderButton.svelte
@@ -8,6 +8,6 @@ import Button from "flowbite-svelte/Button.svelte";
 let { onclick }: { onclick: (event: Event) => void } = $props();
 </script>
 
-<Button color="purple" {onclick}>
-    <ArrowUpDownOutline class="me-2 h-5 w-5"/> {i18n.tr.admin.reorder}
+<Button aria-roledescription={i18n.tr.admin.reorder} class="btn-secondary btn-icon btn-icon-rounded" {onclick}>
+    <ArrowUpDownOutline class="h-5 w-5"/>
 </Button>

--- a/frontend/src/lib/components/Admin/SaveButton.svelte
+++ b/frontend/src/lib/components/Admin/SaveButton.svelte
@@ -12,7 +12,7 @@ let {
 }: { onclick: () => void; text?: string; disabled?: boolean } = $props();
 </script>
 
-<Button color="green" {onclick} {disabled}
+<Button class="btn-secondary" {onclick} {disabled}
 >
-    <CheckOutline class="me-2 h-5 w-5"/> {text}</Button
->
+    <CheckOutline class="me-2 h-5 w-5"/> {text}
+</Button>

--- a/frontend/src/lib/components/Admin/Users.svelte
+++ b/frontend/src/lib/components/Admin/Users.svelte
@@ -81,52 +81,54 @@ onMount(async () => {
 	<h3 class="mb-3 text-xl font-medium text-gray-900 dark:text-white">
 		{i18n.tr.admin.users}
 	</h3>
-	<Table>
-		<TableHead>
-			<TableHeadCell>Email</TableHeadCell>
-			<TableHeadCell>Active</TableHeadCell>
-			<TableHeadCell>Verified</TableHeadCell>
-			<TableHeadCell>Researcher</TableHeadCell>
-			<TableHeadCell>Full data access</TableHeadCell>
-			<TableHeadCell>Research Code</TableHeadCell>
-			<TableHeadCell>Admin</TableHeadCell>
-			<TableHeadCell>{i18n.tr.admin.actions}</TableHeadCell>
-		</TableHead>
-		<TableBody>
-			{#each users as user (user.id)}
-				<TableBodyRow>
-					<TableBodyCell>
-						{user.email}
-					</TableBodyCell>
-					<TableBodyCell>
-						<Checkbox bind:checked={user.is_active} onchange={() => {saveDisabled[user.id]=false}} />
-					</TableBodyCell>
-					<TableBodyCell>
-						<Checkbox bind:checked={user.is_verified} onchange={() => {saveDisabled[user.id]=false}} />
-					</TableBodyCell>
-					<TableBodyCell>
-						<Checkbox bind:checked={user.is_researcher} onchange={() => {saveDisabled[user.id]=false}} />
-					</TableBodyCell>
-					<TableBodyCell>
-						<Checkbox bind:checked={user.full_data_access} onchange={() => {saveDisabled[user.id]=false}} />
-					</TableBodyCell>
-					<TableBodyCell>
-						{#if user.research_group_id > 0}
-						<Alert border={user.is_researcher} color="dark">
-							{user.research_group_id}
-						</Alert>
-							{:else if user.is_researcher}
-							<Button onclick={() => {addResearchGroup(user)}}>Add research code</Button>
-						{/if}
-					</TableBodyCell>
-					<TableBodyCell>
-						<Checkbox bind:checked={user.is_superuser} onchange={() => {saveDisabled[user.id]=false}} />
-					</TableBodyCell>
-					<TableBodyCell>
-						<SaveButton disabled={saveDisabled[user.id]} onclick={() => {updateUser(user)}} />
-					</TableBodyCell>
-				</TableBodyRow>
-			{/each}
-		</TableBody>
-	</Table>
+	<div class="overflow-x-scroll overflow-y-scroll">
+		<Table class="w-max max-h-[600px]">
+			<TableHead>
+				<TableHeadCell>Email</TableHeadCell>
+				<TableHeadCell>Active</TableHeadCell>
+				<TableHeadCell>Verified</TableHeadCell>
+				<TableHeadCell>Researcher</TableHeadCell>
+				<TableHeadCell>Full data access</TableHeadCell>
+				<TableHeadCell>Research Code</TableHeadCell>
+				<TableHeadCell>Admin</TableHeadCell>
+				<TableHeadCell>{i18n.tr.admin.actions}</TableHeadCell>
+			</TableHead>
+			<TableBody>
+				{#each users as user (user.id)}
+					<TableBodyRow>
+						<TableBodyCell>
+							{user.email}
+						</TableBodyCell>
+						<TableBodyCell>
+							<Checkbox bind:checked={user.is_active} onchange={() => {saveDisabled[user.id]=false}} />
+						</TableBodyCell>
+						<TableBodyCell>
+							<Checkbox bind:checked={user.is_verified} onchange={() => {saveDisabled[user.id]=false}} />
+						</TableBodyCell>
+						<TableBodyCell>
+							<Checkbox bind:checked={user.is_researcher} onchange={() => {saveDisabled[user.id]=false}} />
+						</TableBodyCell>
+						<TableBodyCell>
+							<Checkbox bind:checked={user.full_data_access} onchange={() => {saveDisabled[user.id]=false}} />
+						</TableBodyCell>
+						<TableBodyCell>
+							{#if user.research_group_id > 0}
+							<Alert border={user.is_researcher} color="dark">
+								{user.research_group_id}
+							</Alert>
+								{:else if user.is_researcher}
+								<Button onclick={() => {addResearchGroup(user)}}>Add research code</Button>
+							{/if}
+						</TableBodyCell>
+						<TableBodyCell>
+							<Checkbox bind:checked={user.is_superuser} onchange={() => {saveDisabled[user.id]=false}} />
+						</TableBodyCell>
+						<TableBodyCell>
+							<SaveButton disabled={saveDisabled[user.id]} onclick={() => {updateUser(user)}} />
+						</TableBodyCell>
+					</TableBodyRow>
+				{/each}
+			</TableBody>
+		</Table>
+	</div>
 </Card>

--- a/frontend/src/routes/stylesPreview/+page.svelte
+++ b/frontend/src/routes/stylesPreview/+page.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+import { goto } from "$app/navigation";
+import { Button } from "flowbite-svelte";
+import { BarsOutline } from "flowbite-svelte-icons";
+// Example of primary button
+function handleSignup() {
+	goto("/signup");
+}
+
+// Example of a danger button with icon
+function handleDelete() {
+	// Delete logic here
+}
+</script>
+
+<!-- Primary Button -->
+<Button
+        class="btn-primary"
+        on:click={handleSignup}
+>
+    Sign Up
+</Button>
+
+<!-- Secondary Button -->
+<Button
+        class="btn-secondary"
+        on:click={() => console.log('Secondary action')}
+>
+    Learn More
+</Button>
+
+<!-- Danger Button -->
+<Button
+        class="btn-danger"
+        on:click={handleDelete}
+>
+    <BarsOutline />
+</Button>
+
+<!-- Icon Button -->
+<Button
+        class="btn-icon"
+        on:click={() => console.log('Icon action')}
+>
+    <BarsOutline />
+</Button>
+
+<!-- Outlined Button with Icon -->
+<Button
+        outline
+        class="btn-primary"
+>
+    <BarsOutline /> Edit Profile
+</Button>
+
+<!-- Gradient Button -->
+<Button
+        gradient
+        color="greenToBlue"
+        class="btn-secondary"
+>
+    Gradient Action
+</Button>

--- a/frontend/src/routes/userLand/children/feedback/+page.svelte
+++ b/frontend/src/routes/userLand/children/feedback/+page.svelte
@@ -512,7 +512,7 @@ async function printReport(): Promise<void> {
     <div class="flex flex-col sm:flex-row space-y-2 sm:space-y-0 sm:space-x-2 items-center justify-center m-2 p-2">
         <svelte:component this={symbol} size="xl" class={`${color}`} />
         {#if color !== "gray"}
-			<span class = {`font-bold ${isMilestone? "text-gray-700 dark:text-gray-700": ""}`} >
+			<span class = {`font-bold ${isMilestone? "text-white dark:text-white": ""}`} >
 				{milestone_or_group?.text[i18n.locale].title}
 			</span>
         {/if}
@@ -522,7 +522,7 @@ async function printReport(): Promise<void> {
 
 <!--Snippet defining how the evaluation for each milestonegroup is shown. 'grade' is the evaluation we get from the backend-->
 {#snippet evaluation( milestone_or_group: MilestonePublic | MilestoneGroupPublic | undefined, grade: number, isMilestone: boolean,)}
-    <div class={`rounded-lg space-x-2 space-y-2 justify-center p-2 m-2 flex flex-col text-sm md:text-base ${(grade === 0 || grade === -1) && isMilestone=== true ? "bg-feedback-background-0" : ""}`}>
+    <div class={`rounded-lg space-x-2 space-y-2 justify-center p-2 m-2 flex flex-col text-sm md:text-white ${(grade === 0 || grade === -1) && isMilestone=== true ? "bg-feedback-background-0" : ""}`}>
         {#if grade === 1}
             {@render evaluationElement(CheckCircleSolid, milestone_or_group, "text-feedback-0", isMilestone)}
         {:else if grade === 0}
@@ -536,7 +536,7 @@ async function printReport(): Promise<void> {
                 {@render milestoneHelpButton(milestone_or_group as MilestonePublic)}
             {/if}
         {:else }
-            {@render evaluationElement(CloseCircleSolid, milestone_or_group, "gray", isMilestone)}
+            {@render evaluationElement(CloseCircleSolid, milestone_or_group, "text-white", isMilestone)}
         {/if}
     </div>
 {/snippet}
@@ -547,8 +547,8 @@ async function printReport(): Promise<void> {
         {#each Object.entries(summary[aid]) as [mid, score]}
             <div class="flex flex-col">
                 <AccordionItem
-                        activeClass="hover:scale-105 md:hover:scale-1 flex flex-col rounded-lg text-white dark:text-white bg-primary-700 dark:bg-primary-700 hover:bg-primary-600 dark:hover:bg-primary-600 items-center justify-between w-full font-medium text-left p-1"
-                        inactiveClass="hover:scale-105 md:hover:scale-1 flex flex-col rounded-lg text-white dark:text-white bg-primary-800 dark:bg-primary-800 hover:bg-primary-700 dark:hover:bg-primary-700 items-center justify-between w-full font-medium text-left p-1"
+                        activeClass="hover:scale-105 md:hover:scale-1 flex flex-col rounded-lg text-white dark:text-white bg-milestone-700 dark:bg-milestone-700 hover:bg-milestone-600 dark:hover:bg-milestone-600 items-center justify-between w-full font-medium text-left p-1"
+                        inactiveClass="hover:scale-105 md:hover:scale-1 flex flex-col rounded-lg text-white dark:text-white bg-milestone-800 dark:bg-milestone-800 hover:bg-milestone-700 dark:hover:bg-milestone-700 items-center justify-between w-full font-medium text-left p-1"
                 >
 					<span slot="header" class="items-center flex justify-center py-1">
 						{@render evaluation(milestoneGroups[aid][Number(mid)], score as number, false)}

--- a/frontend/src/routes/userLand/children/feedback/+page.svelte
+++ b/frontend/src/routes/userLand/children/feedback/+page.svelte
@@ -592,9 +592,9 @@ async function printReport(): Promise<void> {
 <!-- Middle part of the page with a buttton that enables the explanation modal for the feedback, and a heading that tells people what they can do next -->
 {#snippet explanationModal()}
     <div class=" flex flex-col md:flex-row items-center text-gray-700 dark:text-gray-200 justify-between m-2 mb-4 pb-4 space-y-2">
-        <h5 class="flex flex-auto font-bold text-md md:text-xl text-gray-700 dark:text-gray-200 m-2 p-2">{i18n.tr.milestone.selectFeedback}</h5>
+        <h5 class="flex flex-auto font-bold text-md md:text-xl m-2 p-2">{i18n.tr.milestone.selectFeedback}</h5>
 
-        <Button class="bg-additional-color-500 dark:bg-additional-color-500 hover:bg-additional-color-400 dark:hover:bg-additional-color-600 focus-within:ring-additional-color-40 text-sm md:text-base" size="md" type="button" on:click={() => {
+        <Button type="button" on:click={() => {
 			showMoreInfo = true;
 		}}
         >{i18n.tr.milestone.moreInfoOnEval}</Button>
@@ -659,7 +659,7 @@ async function printReport(): Promise<void> {
 
     <!--Button to print the report out into pdf or physical copy-->
     <div class="flex items-center justify-center w-full m-2 p-2 mb-4 pb-4">
-        <Button class="text-sm md:text-base md:w-64 md:h-8  m-2 p-2 bg-additional-color-500 dark:bg-additional-color-500 hover:bg-additional-color-400 dark:hover:bg-additional-color-600 focus-within:ring-additional-color-40" onclick={async () => {await printReport();}}>{i18n.tr.milestone.printReport}</Button>
+        <Button class="btn-secondary" onclick={async () => {await printReport();}}>{i18n.tr.milestone.printReport}</Button>
     </div>
 {:catch error}
     {alertStore.showAlert(

--- a/frontend/src/routes/userLand/children/gallery/+page.svelte
+++ b/frontend/src/routes/userLand/children/gallery/+page.svelte
@@ -37,12 +37,12 @@ function createStyle(data: CardElement[]): CardStyle[] {
 				item.header === i18n.tr.childData.newChildHeading
 					? {
 							class:
-								"bg-primary dark:bg-primary child-card hover:cursor-pointer m-2 max-w-prose hover:bg-additional-color-800 dark:hover:bg-additional-color-700 ",
+								"hover:scale-105 bg-primary dark:bg-primary child-card hover:cursor-pointer m-2 max-w-prose hover:bg-additional-color-800 dark:hover:bg-additional-color-700 ",
 							horizontal: false,
 						}
 					: {
 							class:
-								"child-card hover:cursor-pointer m-2 max-w-prose text-gray-700 hover:text-white dark:text-white hover:dark:text-gray-400 hover:bg-primary-800 dark:hover:bg-primary-700",
+								"hover:scale-105 child-card hover:cursor-pointer m-2 max-w-prose text-gray-700 hover:text-white dark:text-white hover:dark:text-gray-400 hover:bg-primary-800 dark:hover:bg-primary-700",
 							style: item.color
 								? `background-color: ${item.color};`
 								: "background-color: white", // default to white for image ones, even on hover.

--- a/frontend/src/routes/userLand/children/registration/+page.svelte
+++ b/frontend/src/routes/userLand/children/registration/+page.svelte
@@ -341,7 +341,7 @@ const deleteCurrentChild = async () => {
                             class="m-1 mb-3 p-1 text-center font-bold tracking-tight text-gray-700 dark:text-gray-400"
                     >{childLabel}
                         {#if disableEdit}
-                            <small class="justify-end">
+                            <span class="justify-end w-full">
                                 <button aria-label={i18n.tr.admin.edit}
                                         type="button"
                                         class="btn-secondary btn-icon"
@@ -361,11 +361,11 @@ const deleteCurrentChild = async () => {
                                     >
                                 {/if}
                                 <DeleteModal bind:open={showDeleteModal} onclick={deleteCurrentChild}></DeleteModal>
-                                <br />
-
+                            </span>
+                            <div>
                                 <span>{i18n.tr.childData.monthYearSubtext} </span>
                                 <span class="text-muted">{birthmonth} / {birthyear}</span>
-                            </small>
+                            </div>
                         {/if}
                     </Heading
                     >
@@ -434,19 +434,15 @@ const deleteCurrentChild = async () => {
 
                             {#if image !== null && disableEdit === false}
                                 <Button
-                                        type="button"
-                                        class="w-full text-center text-sm text-white"
-                                        color={"red"}
+                                        class="btn-icon btn-delete"
                                         disabled={disableImageDelete}
                                         on:click={() => {
-                image = null;
-                disableImageDelete = true;
-                imageDeleted = true;
-            }}
+                                        image = null;
+                                        disableImageDelete = true;
+                                        imageDeleted = true;
+                                    }}
                                 >
-                                    <div class="flex items-center justify-center">
-                                        <TrashBinOutline size="sm"/> {i18n.tr.childData.deleteImageButton}
-                                    </div>
+                                    <TrashBinOutline size="sm"/> {i18n.tr.childData.deleteImageButton}
                                 </Button>
                             {:else if disableImageDelete === true}
                                 <p class="text-center text-sm text-gray-700 dark:text-gray-400 flex items-center justify-center">
@@ -485,15 +481,15 @@ const deleteCurrentChild = async () => {
 
 
                         {#if currentChild.id !== null && disableEdit === true}
-                            <a
+                            <Button
                                     class="btn-secondary"
                                     onclick={() => {
                                         goto(`/userLand/children/feedback`)
                                     }}>
                                 <ChartLineUpOutline size="md" />
                                 {i18n.tr.childData.feedbackButtonLabel}
-                            </a>
-                            <a
+                            </Button>
+                            <Button
                                     class="btn-primary"
                                     onclick={() => {
                                         goto(`/userLand/milestone/group`)
@@ -501,7 +497,7 @@ const deleteCurrentChild = async () => {
                             >
                                 <FlagOutline size="md" />
                                 {i18n.tr.childData.nextButtonLabel}
-                            </a>
+                            </Button>
 
                         {/if}
                     </form>

--- a/frontend/src/routes/userLand/children/registration/+page.svelte
+++ b/frontend/src/routes/userLand/children/registration/+page.svelte
@@ -341,31 +341,31 @@ const deleteCurrentChild = async () => {
                             class="m-1 mb-3 p-1 text-center font-bold tracking-tight text-gray-700 dark:text-gray-400"
                     >{childLabel}
                         {#if disableEdit}
-                            <span class="justify-end w-full">
-                                <button aria-label={i18n.tr.admin.edit}
+                            <div class="justify-end">
+                                <Button aria-label={i18n.tr.admin.edit}
                                         type="button"
-                                        class="btn-secondary btn-icon"
+                                        class="btn-secondary btn-icon "
                                         onclick={() => {
                             disableEdit = false;
                         }}
                                 >
-                                    <PenOutline size="md" />
-                                </button>
+                                    <PenOutline class="h-5 w-5" />
+                                </Button>
 
                                 {#if currentChild.id !== null && disableEdit === true}
-                                    <button
+                                    <Button
                                             class="btn-danger btn-icon"
                                             aria-label={i18n.tr.admin.delete}
                                             onclick={() => showDeleteModal = true}
-                                    ><TrashBinOutline size="md"/></button
+                                    ><TrashBinOutline class="h-5 w-5" /></Button
                                     >
                                 {/if}
                                 <DeleteModal bind:open={showDeleteModal} onclick={deleteCurrentChild}></DeleteModal>
-                            </span>
-                            <div>
+                            </div>
+                            <small class="block text-muted">
                                 <span>{i18n.tr.childData.monthYearSubtext} </span>
                                 <span class="text-muted">{birthmonth} / {birthyear}</span>
-                            </div>
+                            </small>
                         {/if}
                     </Heading
                     >

--- a/frontend/src/routes/userLand/milestone/group/+page.svelte
+++ b/frontend/src/routes/userLand/milestone/group/+page.svelte
@@ -188,7 +188,7 @@ export function createStyle(data: any[]) {
 		return {
 			card: {
 				class:
-					"m-2 max-w-prose dark:text-white text-white hover:cursor-pointer bg-primary-700 dark:bg-primary-900 hover:bg-primary-800 dark:hover:bg-primary-700",
+					"m-2 max-w-prose dark:text-white text-white hover:cursor-pointer bg-milestone-700 dark:bg-milestone-900 hover:bg-milestone-800 dark:hover:bg-milestone-700",
 			},
 			progress: {
 				labelInside: true,

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -9,6 +9,7 @@ export default {
 		"./node_modules/flowbite-svelte/**/*.{html,js,svelte,ts}",
 	],
 	darkMode: "selector",
+	// ensure svelte compiler doesn't optimize these away if it doesn't realise we are using them
 	safelist: [
 		"bg-milestone-answer-0",
 		"bg-milestone-answer-1",

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -21,7 +21,7 @@ export default {
 				// From your original additional-color in CSS
 				primary: {
 					50: "#E2F1F0",
-					100: "#D5EAE9",
+					100: "rgb(50,50,50)",
 					200: "#C7E3E2",
 					300: "#B6DBDA",
 					400: "#A5D2D1",
@@ -43,6 +43,19 @@ export default {
 					700: "#698584",
 					800: "#556C6B",
 					900: "#4D6261",
+				},
+
+				milestone: {
+					50: "#DDE1ED",
+					100: "#D5D9E9",
+					200: "#BAC1DA",
+					300: "#9AA5C9",
+					400: "#8592BE",
+					500: "#6C7BB0",
+					600: "#5D6EA8",
+					700: "#556499",
+					800: "#4D5B8B",
+					900: "#46537E",
 				},
 
 				// Custom colors for special backgrounds
@@ -127,8 +140,8 @@ export default {
 				".btn-danger": {
 					"@apply inline-flex items-center justify-center gap-2 font-semibold rounded-lg shadow-md focus:outline-none focus:ring focus:ring-red-400 focus:ring-opacity-75 text-btn text-red-700":
 						{},
-					border: "2px solid rgba(200, 30, 30, 0.6)!important",
-					"background-color": "rgba(200, 30, 30, 0.1)!important",
+					"background-color": "#e5f4f4!important",
+					border: "2px solid rgb(124, 158, 157)",
 					color: "rgba(200, 30, 30, 0.8)!important",
 					"&:hover": {
 						border: "2px solid rgb(240, 82, 82)",
@@ -140,6 +153,7 @@ export default {
 				},
 				".btn-icon": {
 					"min-width": "unset",
+					"background-color": "white!important",
 					"@apply py-2 px-2": {},
 				},
 				".bg-special": {

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -151,11 +151,6 @@ export default {
 					},
 					"@apply dark:text-white": {},
 				},
-				".btn-icon": {
-					"min-width": "unset",
-					"background-color": "white!important",
-					"@apply py-2 px-2": {},
-				},
 				".bg-special": {
 					"background-color": "rgba(124, 158, 157, 0.15)",
 					color: "rgba(255, 255, 255, 0.925)",

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -9,7 +9,6 @@ export default {
 		"./node_modules/flowbite-svelte/**/*.{html,js,svelte,ts}",
 	],
 	darkMode: "selector",
-	// ensure svelte compiler doesn't optimize these away if it doesn't realise we are using them
 	safelist: [
 		"bg-milestone-answer-0",
 		"bg-milestone-answer-1",
@@ -19,18 +18,18 @@ export default {
 	theme: {
 		extend: {
 			colors: {
-				// flowbite-svelte
+				// From your original additional-color in CSS
 				primary: {
-					50: "#DDE1ED",
-					100: "#D5D9E9",
-					200: "#BAC1DA",
-					300: "#9AA5C9",
-					400: "#8592BE",
-					500: "#6C7BB0",
-					600: "#5D6EA8",
-					700: "#556499",
-					800: "#4D5B8B",
-					900: "#46537E",
+					50: "#E2F1F0",
+					100: "#D5EAE9",
+					200: "#C7E3E2",
+					300: "#B6DBDA",
+					400: "#A5D2D1",
+					500: "#96BFBE",
+					600: "#89b3b2",
+					700: "#7C9E9D", // This is rgb(124, 158, 157)
+					800: "#556C6B",
+					900: "#4D6261",
 				},
 
 				"additional-color": {
@@ -40,11 +39,16 @@ export default {
 					300: "#B6DBDA",
 					400: "#A5D2D1",
 					500: "#96BFBE",
-					600: "#7C9E9D",
+					600: "#7C9E9D", // This is rgb(124, 158, 157)
 					700: "#698584",
 					800: "#556C6B",
 					900: "#4D6261",
 				},
+
+				// Custom colors for special backgrounds
+				"special-bg": "rgba(124, 158, 157, 0.15)",
+				"delete-bg": "rgba(200, 30, 30, 0.1)",
+				"delete-hover": "rgba(200, 30, 30, 0.6)",
 
 				"milestone-answer": {
 					0: "#f2e8cf",
@@ -77,5 +81,86 @@ export default {
 		},
 	},
 
-	plugins: [flowbitePlugin, typographyPlugin],
+	plugins: [
+		flowbitePlugin,
+		typographyPlugin,
+		({ addComponents, theme }) => {
+			addComponents({
+				".btn": {
+					cursor: "pointer",
+					"transition-property": "all",
+					"transition-timing-function": "cubic-bezier(0.4, 0, 0.2, 1)",
+					"transition-duration": "100ms",
+				},
+				".text-btn": {
+					"padding-top": "0.5rem",
+					"padding-bottom": "0.5rem",
+					"padding-left": "1.25rem",
+					"padding-right": "1.25rem",
+					"border-radius": "0.375rem",
+					"min-width": "12rem",
+					margin: "0.25rem",
+				},
+				".btn-primary": {
+					"@apply inline-flex items-center justify-center gap-2 text-white font-semibold bg-additional-color-600 rounded-lg shadow-md focus:outline-none focus:ring focus:ring-additional-color-300 focus:ring-opacity-75 text-btn":
+						{},
+					border: "2px solid rgb(124, 158, 157)",
+					"background-color": "rgb(124, 158, 157)",
+					"&:hover": {
+						"bg-additional-color-700": {},
+						border: "2px solid #556C6B!important;",
+					},
+				},
+				".btn-secondary": {
+					"@apply text-additional-color-700 inline-flex items-center justify-center gap-2 font-semibold rounded-lg shadow-md focus:outline-none focus:ring focus:ring-additional-color-300 focus:ring-opacity-75 text-btn text-additional-color-700":
+						{},
+					border: "2px solid rgb(124, 158, 157)",
+					"background-color": "#e5f4f4!important",
+					color: "#698584!important",
+					"&:hover": {
+						"background-color": "#96BFBE!important",
+						border: "2px solid #96BFBE!important",
+						color: "white!important",
+					},
+					"@apply dark:bg-special-bg dark:text-white": {},
+				},
+				".btn-danger": {
+					"@apply inline-flex items-center justify-center gap-2 font-semibold rounded-lg shadow-md focus:outline-none focus:ring focus:ring-red-400 focus:ring-opacity-75 text-btn text-red-700":
+						{},
+					border: "2px solid rgba(200, 30, 30, 0.6)!important",
+					"background-color": "rgba(200, 30, 30, 0.1)!important",
+					color: "rgba(200, 30, 30, 0.8)!important",
+					"&:hover": {
+						border: "2px solid rgb(240, 82, 82)",
+						"background-color": "rgba(200, 30, 30, 0.3)!important",
+						color: "rgba(200, 30, 30, 1)!important",
+						"@apply text-white bg-red-500": {},
+					},
+					"@apply dark:text-white": {},
+				},
+				".btn-icon": {
+					"min-width": "unset",
+					"@apply py-2 px-2": {},
+				},
+				".bg-special": {
+					"background-color": "rgba(124, 158, 157, 0.15)",
+					color: "rgba(255, 255, 255, 0.925)",
+				},
+				// Make sure icons have consistent vertical alignment
+				".btn-primary svg, .btn-secondary svg, .btn-danger svg": {
+					"@apply inline-block align-middle": {},
+				},
+				// Media query for mobile responsiveness
+				"@media only screen and (min-device-width: 320px) and (max-device-width: 480px)":
+					{
+						".btn": {
+							"min-width": "100%",
+						},
+						".btn-icon": {
+							"min-width": "unset",
+						},
+					},
+			});
+		},
+	],
 } as Config;


### PR DESCRIPTION
Now the tailwind theme uses the blue/green teal color. Interactive parts of the site use this color, including <Buttons>, <buttons>, some form element outlines, and <a links in text form (e.g. "Forgot password" on the login page). Future flowbite svelte components, tables, accordions etc, should all work with this theming.

Additionally, milestone buttons remain with the "Blue" color.

I prioritized using tailwind theming for future flowbite component use compatibility, but some exceptions remain hardcoded in app.css, mostly for icons, a media query, and app basics. I also felt setting up SCSS might not be worth it. The tradeoff with that is that theming works great, but we are not using variables as much as ideal (For example, some hardcoded colors in the tailwind theme config are repeated).

This will close #235
