### PR TITLE
Improve and document email deployment setup

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -80,3 +80,78 @@ Until this is done the new text will not be visible in the deployed website!_
 The automatic translation buttons in the admin interface use the DeepL API to translate text.
 To use this feature, an API key is needed which can be set in the `.env` file where the docker-compose.yml is located.
 The DeepL API Free plan currently offers 500,000 characters per month for free, which should be sufficient (a credit card is required at sign up but is not charged).
+
+### Emails
+
+#### SMTP
+
+The emails sent from the website are sent using SMTP.
+The SMTP server and credentials can be configured by setting these environment variables:
+
+- `SMTP_HOST`
+- `SMTP_USERNAME`
+- `SMTP_PASSWORD`
+
+By default this is set to use the postfix send-only docker image included in the docker compose,
+but if you have an email account you wish to use instead you can set these SMTP server and credentials accordingly.
+
+The postfix image will by default try to send emails directly using port 25.
+Some ISPs and networks block this port, but may provide a SMTP relay service that should be used instead.
+This can be configured by setting these environment variables:
+
+- `RELAYHOST`
+- `RELAYHOST_USERNAME`
+- `RELAYHOST_PASSWORD`
+
+Currently the website is hosted on a heicloud VM, which uses the heidelberg university network SMTP relay (`relays.uni-heidelberg.de:25`, no username/password) to send emails.
+
+#### DNS
+
+In order to avoid emails being sent to spam, there are several DNS security features that should be configured.
+
+**SPF record**
+
+- adds the IP address of the mail server(s) allowed to send emails from this website to the DNS info
+- if using a commercial mail sending service they will provide this info
+- for heidelberg uni
+  - we can look it up: https://mxtoolbox.com/SuperTool.aspx?action=spf%3auni-heidelberg.de&run=toolpage
+  - for the temporary namecheap sub-domain mondey.lkeegan.dev:
+    - Type: `TXT Record`
+    - Host: `mondey`
+    - Value: `v=spf1 ip4:129.206.100.212 ip4:129.206.119.212 ip4:129.206.100.213 include:spf.protection.outlook.com mx -all`
+- check the changes worked with e.g. https://dmarcian.com/spf-survey/?domain=mondey.lkeegan.dev
+
+**DKIM**
+
+- adds a public key to the DNS info
+- sent emails are signed with this key by the email server
+- if using a commercial mail sending service they will provide this info
+- for heidelberg uni
+  - postfix docker image will generate DKIM keys if not already present with selector `mail`
+  - copy the generated dns entry from opendkim-keys/mondey.lkeegan.dev.txt
+    - note remove any quotes and newlines and spaces after `p=`!
+  - for the temporary namecheap sub-domain mondey.lkeegan.dev:
+    - Type: `TXT Record`
+    - Host: `mail._domainkey.mondey`
+    - Value: `v=DKIM1; h=sha256; k=rsa; s=email; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu1s+IQlEUKtJ6Gt2/h5x7M949Vdmue7A5al2asflVXTvw7me8OCCsYx2FaWjLDPNpXHxEhUVYqJQKUTyvZnpjIxBXg86hSnBaO0YUQXsE2pz4jNt9BOEGhKACc47DkJEg3XOcJqf7JnrWkOELLnWS2RKzDUZ3e1/5cjolvtJuMEQFay1EITCamCJOUsA+gZ12XC4j10k3aT/MPxhOG9Wj8VhD7eLHI0QV1XRD7DrzO7EyA9R/Eve/l1FGx5CzuNIjKhmb1FVGiepqkPZgooDs9hxXCElQVqP6CQFyDRY64SiV1kTfVVSvL1N5PiU2BxP2IKKaXvn4/H55Zjz5j1+sQIDAQAB`
+- to check this entry is valid before using: e.g. https://dmarcian.com/dkim-validator/
+- check the changes worked with e.g.: e.g. https://dmarcian.com/dkim-inspector/?domain=mondey.lkeegan.dev&selector=mail
+
+**DMARC record**
+
+- DMARC policy indicates valid spf/dkim and what to do if not
+- if using a commercial mail sending service they will provide this info
+- for the temporary namecheap sub-domain mondey.lkeegan.dev:
+  - Type: `TXT Record`
+  - Host: `_dmarc.mondey`
+  - Value: `v=DMARC1; p=reject`
+- check the changes worked with e.g. https://dmarcian.com/dmarc-inspector/?domain=mondey.lkeegan.dev
+
+**Testing**
+
+Some resources to check if all this worked:
+
+- https://www.mail-tester.com/
+- https://easydmarc.com/tools/domain-scanner?domain=mondey.lkeegan.dev
+- https://mxtoolbox.com/SuperTool.aspx
+- https://www.mail-tester.com/spf-dkim-check

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       - HOST=${HOST:-backend}
       - PORT=${PORT:-80}
       - SMTP_HOST=${SMTP_HOST:-email:587}
+      - SMTP_USERNAME=${SMTP_USERNAME:-}
+      - SMTP_PASSWORD=${SMTP_PASSWORD:-}
       - RELOAD=false
       - LOG_LEVEL=${LOG_LEVEL:-info}
       - COOKIE_SECURE=${COOKIE_SECURE:-true}
@@ -46,8 +48,16 @@ services:
         max-file: 25
   email:
     image: "boky/postfix"
+    hostname: mail.mondey.lkeegan.dev
+    restart: always
     environment:
-      - ALLOW_EMPTY_SENDER_DOMAINS="true"
+      - RELAYHOST=${RELAYHOST:-}
+      - POSTFIX_myhostname=mail.mondey.lkeegan.dev
+      - POSTFIX_mydomain=mondey.lkeegan.dev
+      - ALLOWED_SENDER_DOMAINS=mondey.lkeegan.dev
+      - DKIM_AUTOGENERATE=true
+    volumes:
+      - ./opendkim-keys:/etc/opendkim/keys
     logging:
       driver: "local"
       options:

--- a/mondey_backend/src/mondey_backend/main.py
+++ b/mondey_backend/src/mondey_backend/main.py
@@ -72,7 +72,7 @@ def main():
     logger = logging.getLogger(__name__)
     for key, value in app_settings:
         logger.info(
-            f"{key}: {'****************' if key in {'SECRET', 'DEEPL_API_KEY'} else value}"
+            f"{key}: {'****************' if key in {'SECRET', 'DEEPL_API_KEY', 'SMTP_PASSWORD'} else value}"
         )
     uvicorn.run(
         "mondey_backend.main:create_app",

--- a/mondey_backend/src/mondey_backend/settings.py
+++ b/mondey_backend/src/mondey_backend/settings.py
@@ -15,6 +15,8 @@ class AppSettings(BaseSettings):
     HOST: str = "localhost"
     PORT: int = 8000
     SMTP_HOST: str = ""
+    SMTP_USERNAME: str = ""
+    SMTP_PASSWORD: str = ""
     RELOAD: bool = True
     LOG_LEVEL: str = "debug"
     COOKIE_SECURE: bool = False

--- a/mondey_backend/src/mondey_backend/users.py
+++ b/mondey_backend/src/mondey_backend/users.py
@@ -28,11 +28,17 @@ from .settings import app_settings
 
 
 def send_email(msg: EmailMessage) -> None:
-    if app_settings.SMTP_HOST != "":
-        with smtplib.SMTP(app_settings.SMTP_HOST) as s:
-            s.send_message(msg)
-    else:
-        logging.warning(f"Email {msg} not sent as SMTP_HOST is not set")
+    try:
+        if app_settings.SMTP_HOST != "":
+            with smtplib.SMTP(app_settings.SMTP_HOST) as s:
+                if app_settings.SMTP_USERNAME != "":
+                    s.login(app_settings.SMTP_USERNAME, app_settings.SMTP_PASSWORD)
+                s.send_message(msg)
+        else:
+            logging.warning(f"Email {msg} not sent as SMTP_HOST is not set")
+    except smtplib.SMTPException as e:
+        logging.error(f"Email {msg} not sent due to SMTP error: {e}")
+        logging.exception(e)
 
 
 def send_email_validation_link(email: str, token: str) -> None:

--- a/mondey_backend/tests/conftest.py
+++ b/mondey_backend/tests/conftest.py
@@ -935,7 +935,9 @@ def app(
 ):
     settings.app_settings.STATIC_FILES_PATH = str(static_dir)
     settings.app_settings.PRIVATE_FILES_PATH = str(private_dir)
-    settings.app_settings.SMTP_HOST = "smtp"
+    settings.app_settings.SMTP_HOST = "smtp-host"
+    settings.app_settings.SMTP_USERNAME = "test-smtp-username"
+    settings.app_settings.SMTP_PASSWORD = "test-smtp-password"
     app = create_app()
     app.dependency_overrides[get_session] = lambda: session
     app.dependency_overrides[get_async_session] = lambda: user_session

--- a/mondey_backend/tests/routers/test_auth.py
+++ b/mondey_backend/tests/routers/test_auth.py
@@ -11,6 +11,8 @@ from mondey_backend.models.users import User
 
 class SMTPMock:
     last_message: EmailMessage | None = None
+    username: str | None = None
+    password: str | None = None
 
     def __init__(self, *args, **kwargs):
         pass
@@ -23,6 +25,10 @@ class SMTPMock:
 
     def send_message(self, msg: EmailMessage, **kwargs):
         SMTPMock.last_message = msg
+
+    def login(self, username: str, password: str):
+        SMTPMock.username = username
+        SMTPMock.password = password
 
 
 @pytest.fixture
@@ -41,6 +47,8 @@ def test_register_new_user(public_client: TestClient, smtp_mock: SMTPMock):
     assert response.status_code == 201
     msg = smtp_mock.last_message
     assert msg is not None
+    assert smtp_mock.username == "test-smtp-username"
+    assert smtp_mock.password == "test-smtp-password"
     assert "aktivieren" in msg.get("Subject").lower()
     assert msg.get("To") == email
     assert "/verify/" in msg.get_content()


### PR DESCRIPTION
- backend
  - add username/password for smtp server to settings
    - if provided, use them when authenticating with the SMTP server
- docker-compose.yaml
  - add new settings variables
  - set postfix image to autogenerate DKIM keys
- deployment docs
  - how to use another SMTP server to send emails
  - how to use a relay host if using the docker postfix image to send emails
  - how to configure SPF/DKIM/DMARC DNS settings
- resolves #288