### PR TITLE
Minor changes to support imported survey data

### DIFF
--- a/frontend/src/lib/components/Admin/EditMilestoneModal.svelte
+++ b/frontend/src/lib/components/Admin/EditMilestoneModal.svelte
@@ -19,6 +19,7 @@ import { i18n } from "$lib/i18n.svelte";
 import {
 	Button,
 	ButtonGroup,
+	Input,
 	InputAddon,
 	Label,
 	Modal,
@@ -80,6 +81,10 @@ async function deleteMilestoneImageAndUpdate() {
 
 <Modal title={i18n.tr.admin.edit} bind:open size="xl" outsideclose>
     {#if milestone}
+        <div class="mb-5">
+            <Label class="mb-2">{i18n.tr.admin.name}</Label>
+            <Input bind:value={milestone.name} placeholder={i18n.tr.admin.name}/>
+        </div>
         {#each textKeys as textKey}
             {@const title = i18n.tr.admin[textKey]}
             <div class="mb-5">

--- a/frontend/src/lib/translations.ts
+++ b/frontend/src/lib/translations.ts
@@ -95,6 +95,7 @@ export const translationIds = {
 	admin: {
 		label: "Administration",
 		title: "Titel",
+		name: "Name",
 		languages: "Sprachen",
 		milestone: "Meilenstein",
 		milestones: "Meilensteine",

--- a/frontend/src/routes/userLand/research/+page.svelte
+++ b/frontend/src/routes/userLand/research/+page.svelte
@@ -45,9 +45,11 @@ let df_out = $derived.by(() => {
 	if (df_in === null || df_in.size === 0) {
 		return new DataFrame();
 	}
-	let grp = df_in.groupby(
-		["milestone_id", "child_age"].concat(selected_columns),
-	);
+	let grp = df_in
+		.loc({
+			rows: df_in.milestone_id.eq(selected_milestone_id),
+		})
+		.groupby(["milestone_id", "child_age"].concat(selected_columns));
 	let df = grp.col(["answer"]).mean();
 	df.addColumn("answer_std", grp.col(["answer"]).std().answer_std, {
 		inplace: true,
@@ -63,9 +65,7 @@ let json_data = $derived.by(() => {
 	if (!df_out || !df_out.milestone_id) {
 		return [];
 	}
-	return toJSON(
-		df_out.loc({ rows: df_out.milestone_id.eq(selected_milestone_id) }),
-	) as [];
+	return toJSON(df_out) as [];
 });
 
 let plot_data: PlotDatum[] = $derived.by(() => {
@@ -88,7 +88,11 @@ let plot_data: PlotDatum[] = $derived.by(() => {
 	}
 	for (const key in colDict) {
 		for (const [index, age] of colDict[key].child_age.entries()) {
-			plot_data[age - 1][key] = colDict[key].answer_mean[index];
+			if (age < 1 || age > 72) {
+				console.log(age);
+			} else {
+				plot_data[age - 1][key] = colDict[key].answer_mean[index];
+			}
 		}
 	}
 	return plot_data;

--- a/mondey_backend/src/mondey_backend/models/milestones.py
+++ b/mondey_backend/src/mondey_backend/models/milestones.py
@@ -100,6 +100,7 @@ class Milestone(SQLModel, table=True):
     group: MilestoneGroup = back_populates("milestones")
     text: Mapped[dict[str, MilestoneText]] = dict_relationship(key="lang_id")
     images: Mapped[list[MilestoneImage]] = back_populates("milestone")
+    name: str
 
 
 class MilestonePublic(SQLModel):
@@ -107,6 +108,7 @@ class MilestonePublic(SQLModel):
     expected_age_months: int
     text: dict[str, MilestoneTextPublic]
     images: list[MilestoneImagePublic]
+    name: str
 
 
 class MilestoneAdmin(SQLModel):
@@ -116,6 +118,7 @@ class MilestoneAdmin(SQLModel):
     expected_age_months: int
     text: dict[str, MilestoneText]
     images: list[MilestoneImage]
+    name: str
 
 
 ## MilestoneImage
@@ -157,7 +160,7 @@ class MilestoneAnswer(SQLModel, table=True):
         default=None, foreign_key="milestone.id", primary_key=True
     )
     milestone_group_id: int = Field(default=None, foreign_key="milestonegroup.id")
-    answer: int
+    answer: int  # ranges from 0-3, where 0 is noch gar nichts and 3 is zuverlaessig, or -1 if not answered.
 
 
 class MilestoneAnswerSession(SQLModel, table=True):

--- a/mondey_backend/src/mondey_backend/routers/admin_routers/milestones.py
+++ b/mondey_backend/src/mondey_backend/routers/admin_routers/milestones.py
@@ -7,6 +7,7 @@ from sqlmodel import col
 from sqlmodel import select
 
 from ...dependencies import SessionDep
+from ...dependencies import UserAsyncSessionDep
 from ...models.milestones import Language
 from ...models.milestones import Milestone
 from ...models.milestones import MilestoneAdmin
@@ -20,6 +21,7 @@ from ...models.milestones import MilestoneText
 from ...models.milestones import SubmittedMilestoneImage
 from ...models.milestones import SubmittedMilestoneImagePublic
 from ...models.utils import ItemOrder
+from ...statistics import async_update_stats
 from ..utils import add
 from ..utils import get
 from ..utils import milestone_group_image_path
@@ -192,7 +194,17 @@ def create_router() -> APIRouter:
                 404,
                 detail='"No milestone age score collection with id: ", milestone_id',
             )
-
         return collection
+
+    @router.post(
+        "/update-stats/{incremental_update}",
+        response_model=str,
+    )
+    async def admin_update_stats(
+        session: SessionDep, user_session: UserAsyncSessionDep, incremental_update: bool
+    ):
+        return await async_update_stats(
+            session, user_session, incremental_update=incremental_update
+        )
 
     return router

--- a/mondey_backend/src/mondey_backend/statistics.py
+++ b/mondey_backend/src/mondey_backend/statistics.py
@@ -164,7 +164,7 @@ def _get_statistics_by_age(
         Updated count, avg and stddev arrays.
     """
     if count is None or avg is None or stddev is None:
-        max_age_months = 72
+        max_age_months = 100
         count = np.zeros(max_age_months + 1, dtype=np.int32)
         avg = np.zeros(max_age_months + 1, dtype=np.float64)
         stddev = np.zeros(max_age_months + 1, dtype=np.float64)


### PR DESCRIPTION
- backend
  - add `name` to Milestone database model
- admin page
  - add name to editable fields for a Milestone in EditMilestoneModal
- research page
  - ignore any data with age outside of range 1-72 when plotting
  - only do groupby operation on selected milestone for now to make UI more reponsive
- add `/admin/update-stats` endpoint
  - allows an admin to trigger the stats update manually in addition to the regular cron job update
  - can either do incremental update with only new data, or full re-calculation using all data
  - only API for now, i.e. no button to do this in the admin web interface
- see #284 for the code used to import the survey data