### PR TITLE
273 - Cascade deletes for User & Child questions, milestones & milestone groups (with UI confirmation)

### DIFF
--- a/mondey_backend/src/mondey_backend/models/questions.py
+++ b/mondey_backend/src/mondey_backend/models/questions.py
@@ -4,6 +4,9 @@ from sqlalchemy.orm import Mapped
 from sqlmodel import Field
 from sqlmodel import SQLModel
 
+from .utils import back_populates
+
+# Different format to dict-relationship
 from .utils import dict_relationship
 from .utils import fixed_length_string_field
 
@@ -55,6 +58,9 @@ class UserQuestionText(QuestionTextBase, table=True):
 class UserQuestion(Question, table=True):
     id: int | None = Field(default=None, primary_key=True)
     text: Mapped[dict[str, UserQuestionText]] = dict_relationship(key="lang_id")
+    answers: Mapped[list[UserAnswer]] = back_populates(
+        "question", cascade="all, delete-orphan"
+    )
 
 
 class UserQuestionPublic(QuestionPublic):
@@ -80,6 +86,9 @@ class ChildQuestionText(QuestionTextBase, table=True):
 class ChildQuestion(Question, table=True):
     id: int | None = Field(default=None, primary_key=True)
     text: Mapped[dict[str, ChildQuestionText]] = dict_relationship(key="lang_id")
+    answers: Mapped[list[ChildAnswer]] = back_populates(
+        "question", cascade="all, delete-orphan"
+    )
 
 
 class ChildQuestionPublic(QuestionPublic):
@@ -105,6 +114,7 @@ class UserAnswer(AnswerBase, table=True):
     question_id: int = Field(
         default=None, primary_key=True, foreign_key="userquestion.id"
     )
+    question: UserQuestion = back_populates("answers")
 
 
 class UserAnswerPublic(AnswerPublicBase):
@@ -116,6 +126,7 @@ class ChildAnswer(AnswerBase, table=True):
     question_id: int = Field(
         default=None, primary_key=True, foreign_key="childquestion.id"
     )
+    question: ChildQuestion = back_populates("answers")
 
 
 class ChildAnswerPublic(AnswerPublicBase):

--- a/mondey_backend/src/mondey_backend/routers/admin_routers/milestones.py
+++ b/mondey_backend/src/mondey_backend/routers/admin_routers/milestones.py
@@ -85,13 +85,23 @@ def create_router() -> APIRouter:
 
         if not dry_run:
             affected_milestone_answers = 0
-            deleted_milestone_ids = delete_milestones_with_group_id(
-                session, milestone_group_id, dry_run=False
-            )
-            for milestone_id in deleted_milestone_ids:
+            groups_milestone_ids = session.exec(
+                select(Milestone.id).where(
+                    col(Milestone.group_id) == milestone_group_id
+                )
+            ).all()
+            for milestone_id in [
+                milestone_id
+                for milestone_id in groups_milestone_ids
+                if milestone_id is not None
+            ]:
                 affected_milestone_answers += count_milestone_answers_for_milestone(
                     session, milestone_id
                 )
+
+            deleted_milestone_ids = delete_milestones_with_group_id(
+                session, milestone_group_id, dry_run=False
+            )
 
             session.delete(milestone_group)
             session.commit()

--- a/mondey_backend/src/mondey_backend/routers/admin_routers/questions.py
+++ b/mondey_backend/src/mondey_backend/routers/admin_routers/questions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from fastapi import APIRouter
+from fastapi import Query
 from sqlmodel import col
 from sqlmodel import select
 
@@ -55,11 +56,24 @@ def create_router() -> APIRouter:
         return db_user_question
 
     @router.delete("/user-questions/{user_question_id}")
-    def delete_user_question(session: SessionDep, user_question_id: int):
+    def delete_user_question(
+        session: SessionDep,
+        user_question_id: int,
+        dry_run: bool = Query(
+            True,
+            description="When true, shows what would be deleted without actually deleting",
+        ),
+    ):
         question = get(session, UserQuestion, user_question_id)
+        if dry_run:
+            affected_answers_count = len(question.answers)
+            return {
+                "ok": "True",
+                "would_delete": {"total_answers": affected_answers_count},
+            }
         session.delete(question)
         session.commit()
-        return {"ok": True}
+        return {"ok": True, "deletion_executed": True}
 
     @router.post("/user-questions/order/")
     def order_user_questions_admin(session: SessionDep, item_orders: list[ItemOrder]):
@@ -102,11 +116,24 @@ def create_router() -> APIRouter:
         return db_child_question
 
     @router.delete("/child-questions/{child_question_id}")
-    def delete_child_question(session: SessionDep, child_question_id: int):
+    def delete_child_question(
+        session: SessionDep,
+        child_question_id: int,
+        dry_run: bool = Query(
+            True,
+            description="When true, shows what would be deleted without actually deleting",
+        ),
+    ):
         question = get(session, ChildQuestion, child_question_id)
+        if dry_run:
+            affected_answers_count = len(question.answers)
+            return {
+                "ok": "True",
+                "would_delete": {"total_answers": affected_answers_count},
+            }
         session.delete(question)
         session.commit()
-        return {"ok": True}
+        return {"ok": True, "deletion_executed": True}
 
     @router.post("/child-questions/order/")
     def order_child_questions_admin(session: SessionDep, item_orders: list[ItemOrder]):

--- a/mondey_backend/src/mondey_backend/routers/utils.py
+++ b/mondey_backend/src/mondey_backend/routers/utils.py
@@ -13,8 +13,10 @@ from fastapi import HTTPException
 from fastapi import UploadFile
 from PIL import Image
 from PIL import ImageOps
+from sqlalchemy import func
 from sqlmodel import SQLModel
 from sqlmodel import col
+from sqlmodel import delete
 from sqlmodel import select
 from webp import WebPPreset
 
@@ -297,3 +299,49 @@ def get_milestonegroups_for_answersession(
             select(MilestoneGroup).where(col(MilestoneGroup.id).in_(check_for_overlap))
         ).all()
     }
+
+
+def count_milestone_answers_for_milestone(
+    session: SessionDep, milestone_id: int
+) -> int:
+    count_query = (
+        select(func.count())
+        .select_from(MilestoneAnswer)
+        .where(MilestoneAnswer.milestone_id == milestone_id)
+    )
+    return session.exec(count_query).one()
+
+
+def delete_milestone_by_id(session: SessionDep, milestone_id: int) -> int:
+    milestone = get(session, Milestone, milestone_id)
+    if milestone is None:
+        return 0
+
+    affected_milestone_answer_count = count_milestone_answers_for_milestone(
+        session, milestone_id
+    )
+
+    delete_stmt = delete(MilestoneAnswer).where(
+        col(MilestoneAnswer.milestone_id) == milestone_id
+    )
+    session.execute(delete_stmt)
+
+    session.delete(milestone)
+    session.commit()
+    return affected_milestone_answer_count
+
+
+def delete_milestones_with_group_id(
+    session: SessionDep, milestone_group_id: int, dry_run: bool = True
+) -> list[int]:
+    milestone_ids_query = select(Milestone.id).where(
+        Milestone.group_id == milestone_group_id
+    )
+    milestone_ids_result = session.exec(milestone_ids_query).all()
+    milestone_ids: list[int] = [id for id in milestone_ids_result if id is not None]
+
+    if not dry_run:
+        for milestone_id in milestone_ids:
+            delete_milestone_by_id(session, milestone_id)
+
+    return milestone_ids

--- a/mondey_backend/src/mondey_backend/routers/utils.py
+++ b/mondey_backend/src/mondey_backend/routers/utils.py
@@ -334,10 +334,9 @@ def delete_milestone_by_id(session: SessionDep, milestone_id: int) -> int:
 def delete_milestones_with_group_id(
     session: SessionDep, milestone_group_id: int, dry_run: bool = True
 ) -> list[int]:
-    milestone_ids_query = select(Milestone.id).where(
-        Milestone.group_id == milestone_group_id
-    )
-    milestone_ids_result = session.exec(milestone_ids_query).all()
+    milestone_ids_result = session.exec(
+        select(Milestone.id).where(col(Milestone.group_id) == milestone_group_id)
+    ).all()
     milestone_ids: list[int] = [id for id in milestone_ids_result if id is not None]
 
     if not dry_run:

--- a/mondey_backend/tests/routers/admin_routers/test_admin_milestones.py
+++ b/mondey_backend/tests/routers/admin_routers/test_admin_milestones.py
@@ -4,6 +4,8 @@ import pytest
 from fastapi.testclient import TestClient
 from PIL import Image
 
+from mondey_backend.routers.utils import count_milestone_answers_for_milestone
+
 
 def test_get_milestone_groups(
     admin_client: TestClient, milestone_group_admin1: dict, milestone_group_admin2: dict
@@ -56,15 +58,8 @@ def test_put_milestone_group(admin_client: TestClient, milestone_group_admin1: d
     assert response.json() == milestone_group
 
 
-def test_delete_milestone_group(admin_client: TestClient):
-    response = admin_client.delete("/admin/milestone-groups/2")
-    assert response.status_code == 200
-    response = admin_client.delete("/admin/milestone-groups/2")
-    assert response.status_code == 404
-
-
 def test_delete_milestone_group_invalid_group_id(admin_client: TestClient):
-    response = admin_client.delete("/admin/milestone-groups/692")
+    response = admin_client.delete("/admin/milestone-groups/692?dry_run=false")
     assert response.status_code == 404
 
 
@@ -169,10 +164,10 @@ def test_put_milestone(admin_client: TestClient, milestone_group_admin1: dict):
 
 def test_delete_milestone(admin_client: TestClient):
     assert admin_client.get("/milestones/2").status_code == 200
-    response = admin_client.delete("/admin/milestones/2")
+    response = admin_client.delete("/admin/milestones/2?dry_run=false")
     assert response.status_code == 200
     assert admin_client.get("/milestones/2").status_code == 404
-    response = admin_client.delete("/admin/milestones/2")
+    response = admin_client.delete("/admin/milestones/2?dry_run=false")
     assert response.status_code == 404
 
 
@@ -281,3 +276,123 @@ def test_delete_submitted_milestone_image(
     assert not submitted_image_file.is_file()
     assert not approved_image_file.is_file()
     assert len(admin_client.get("/admin/submitted-milestone-images").json()) == 1
+
+
+"""
+Test that deleting a milestone actually deletes nothing (count milestone answers remains the same) with dry_run = True
+or non-specified dry_run value, and that deleting a milestone with dry_run = False succeeds
+"""
+
+
+def test_delete_milestone_dry_run(admin_client, session):
+    milestone_id = 2
+    expected_answers_from_fixtures = 3  # Has these 3 existing answers in the fixtures.
+    assert (
+        count_milestone_answers_for_milestone(session, milestone_id)
+        == expected_answers_from_fixtures
+    )
+
+    # Fake delete call without dry run param at all (should default to dry run to be safe)
+    response = admin_client.delete(f"/admin/milestones/{milestone_id}")
+    response_json = response.json()
+    assert response.status_code == 200
+    assert response_json["dry_run"]
+    assert "would_delete" in response_json
+    assert response_json["would_delete"]["affected_answers_count"] == 3
+    assert (
+        count_milestone_answers_for_milestone(session, milestone_id)
+        == expected_answers_from_fixtures
+    )
+
+    # Fake delete call with explicit dry_run param set to True
+    response = admin_client.delete(f"/admin/milestones/{milestone_id}?dry_run=true")
+    assert response.status_code == 200
+
+    response_json = response.json()
+    assert response_json["dry_run"]
+    assert "would_delete" in response_json
+    assert response_json["would_delete"]["affected_answers_count"] == 3
+    assert (
+        count_milestone_answers_for_milestone(session, milestone_id)
+        == expected_answers_from_fixtures
+    )
+
+
+def test_delete_milestone_confirmed(admin_client, session):
+    milestone_id = 2
+    expected_answers_from_fixtures = 3  # Has these 3 existing answers in the fixtures.
+    assert (
+        count_milestone_answers_for_milestone(session, milestone_id)
+        == expected_answers_from_fixtures
+    )
+
+    # Real delete call with dry_run param set to False
+    response = admin_client.delete(f"/admin/milestones/{milestone_id}?dry_run=false")
+    assert response.status_code == 200
+    assert response.json()["deletion_executed"]
+    assert count_milestone_answers_for_milestone(session, milestone_id) == 0
+
+
+## Test Delete whole milestone groups:
+def test_delete_milestone_groups_dry_run(admin_client, session):
+    milestone_group_id = (
+        1  # owns milestone ID 1, 2, 3 which have answers respectively of:
+    )
+    # num answers for each milestone: [3, 2, 1]
+    known_first_milestone_id = 1
+    expected_answers_for_first_milestone = 3
+    expected_answers_from_fixtures = (
+        6  # from the 3 milestones in group 1 (setup in conftest fixtures)
+    )
+    assert (
+        count_milestone_answers_for_milestone(session, known_first_milestone_id)
+        == expected_answers_for_first_milestone
+    )
+
+    # Fake delete call without dry run param at all (should default to dry run to be safe)
+    response = admin_client.delete(f"/admin/milestone-groups/{milestone_group_id}")
+    response_json = response.json()
+    assert response.status_code == 200
+    assert response_json["dry_run"]
+    assert "would_delete" in response_json
+    assert (
+        response_json["would_delete"]["affected_answers_count"]
+        == expected_answers_from_fixtures
+    )
+    assert response_json["would_delete"]["milestone_ids"] == [3, 2, 1]
+
+    response = admin_client.delete(f"/admin/milestone-groups/{milestone_group_id}")
+    assert response.status_code == 200  # still exists because was dry run.
+
+
+## Test Delete whole milestone groups:
+def test_delete_milestone_groups_real(admin_client, session):
+    milestone_group_id = (
+        1  # owns milestone ID 1, 2, 3 which have answers respectively of:
+    )
+    # num answers for each milestone: [3, 3, 0] # first two milestones have 3 answers each, last 0.
+    known_first_milestone_id = 1
+    expected_answers_for_first_milestone = 3
+    expected_answers_from_fixtures = (
+        6  # from the 3 milestones in group 1 (setup in conftest fixtures)
+    )
+    assert (
+        count_milestone_answers_for_milestone(session, known_first_milestone_id)
+        == expected_answers_for_first_milestone
+    )
+
+    # Fake delete call without dry run param at all (should default to dry run to be safe)
+    response = admin_client.delete(
+        f"/admin/milestone-groups/{milestone_group_id}?dry_run=false"
+    )
+    response_json = response.json()
+    assert response.status_code == 200
+    assert response_json["deletion_executed"]
+    assert response_json["deleted_milestone_count"] == 3
+    assert response_json["deleted_answer_count"] == expected_answers_from_fixtures
+
+    assert count_milestone_answers_for_milestone(session, known_first_milestone_id) == 0
+    response = admin_client.delete(
+        f"/admin/milestone-groups/{milestone_group_id}?dry_run=false"
+    )
+    assert response.status_code == 404  # gone for good, because was real, not dry_run.

--- a/mondey_backend/tests/routers/test_milestones.py
+++ b/mondey_backend/tests/routers/test_milestones.py
@@ -3,8 +3,6 @@ import pathlib
 import pytest
 from fastapi.testclient import TestClient
 
-from mondey_backend.routers.utils import count_milestone_answers_for_milestone
-
 
 @pytest.mark.parametrize(
     "client_type", ["public_client", "user_client", "research_client", "admin_client"]
@@ -125,62 +123,3 @@ def test_submit_milestone_image_valid(
         )
     assert response.status_code == 200
     assert submitted_image_file.is_file()
-
-
-"""
-Test that deleting a milestone actually deletes nothing (count milestone answers remains the same) with dry_run = True
-or non-specified dry_run value, and that deleting a milestone with dry_run = False succeeds
-"""
-
-
-def test_delete_milestone_dry_run(admin_client, session):
-    milestone_id = 2
-    expected_answers_from_fixtures = 3  # Has these 3 existing answers in the fixtures.
-    print("Testing with dry run..")
-    assert (
-        count_milestone_answers_for_milestone(session, milestone_id)
-        == expected_answers_from_fixtures
-    )
-    print("Expected milestone answers were there.")
-
-    # Fake delete call without dry run param at all (should default to dry run to be safe)
-    response = admin_client.delete(f"/admin/milestones/{milestone_id}")
-    print("Returned something back...,")
-    response_json = response.json()
-    assert response.status_code == 200
-    print(response_json)
-    assert response_json["dry_run"]
-    assert "would_delete" in response_json
-    assert response_json["would_delete"]["affected_answers_count"] == 3
-    assert (
-        count_milestone_answers_for_milestone(session, milestone_id)
-        == expected_answers_from_fixtures
-    )
-
-    # Fake delete call with explicit dry_run param set to True
-    response = admin_client.delete(f"/admin/milestones/{milestone_id}?dry_run=true")
-    assert response.status_code == 200
-
-    response_json = response.json()
-    assert response_json["dry_run"]
-    assert "would_delete" in response_json
-    assert response_json["would_delete"]["affected_answers_count"] == 3
-    assert (
-        count_milestone_answers_for_milestone(session, milestone_id)
-        == expected_answers_from_fixtures
-    )
-
-
-def test_delete_milestone_confirmed(admin_client, session):
-    milestone_id = 2
-    expected_answers_from_fixtures = 3  # Has these 3 existing answers in the fixtures.
-    assert (
-        count_milestone_answers_for_milestone(session, milestone_id)
-        == expected_answers_from_fixtures
-    )
-
-    # Real delete call with dry_run param set to False
-    response = admin_client.delete(f"/admin/milestones/{milestone_id}?dry_run=false")
-    assert response.status_code == 200
-    assert response.json()["deletion_executed"]
-    assert count_milestone_answers_for_milestone(session, milestone_id) == 0

--- a/mondey_backend/tests/utils/test_utils.py
+++ b/mondey_backend/tests/utils/test_utils.py
@@ -3,6 +3,7 @@ from sqlmodel import select
 from mondey_backend.models.milestones import MilestoneAnswerSession
 from mondey_backend.models.milestones import MilestoneGroup
 from mondey_backend.routers.utils import _get_answer_session_child_ages_in_months
+from mondey_backend.routers.utils import count_milestone_answers_for_milestone
 from mondey_backend.routers.utils import get_milestonegroups_for_answersession
 
 
@@ -30,3 +31,15 @@ def test_get_answer_session_child_ages_in_months(session):
     assert child_ages[2] == 8
     assert child_ages[3] == 55
     assert child_ages[99] == 8
+
+
+def test_count_milestone_answers(session):
+    result = count_milestone_answers_for_milestone(session, milestone_id=2)
+    assert type(result) is int
+    assert result == 3
+
+
+def test_count_milestone_answers_non_existing(session):
+    result = count_milestone_answers_for_milestone(session, milestone_id=9999954)
+    assert type(result) is int
+    assert result == 0


### PR DESCRIPTION
@lkeegan the current code implements and tests deletion for all 4 object types in the backend.

I used a different approach for user and child questions (normal cascade) as to milestones/answers. Would be glad to hear your feedback on which approach is better while I complete the frontend confirmation and dry_run functionality to inform the user what they will be deleting.

Do you prefer one way (like using cascades totally) over the other way (for milestones/milestone answers: it manually executes delete queries on related milestones/answers). I was a bit more worried that the performance could be worsened with milestone groups/milestones having cascades to answers, as compared to just questions-answers which are more 1:1 (e.g. if you delete one of the five milestone groups, it might be quite a substantial query for the database?)

The cascade approach uses less code, and is pretty clear, but like you mentioned regarding language, I think it is a bit more risky on the performance side.