### PR TITLE
Fix missing additional_answers in research data

### DIFF
--- a/mondey_backend/tests/conftest.py
+++ b/mondey_backend/tests/conftest.py
@@ -595,7 +595,7 @@ def session(children: list[dict], monkeypatch: pytest.MonkeyPatch):
                 user_id=3,
                 child_id=1,
                 answer="other",
-                additional_answer="dolor sit",
+                additional_answer="apple",
             )
         )
         session.commit()

--- a/mondey_backend/tests/routers/test_research.py
+++ b/mondey_backend/tests/routers/test_research.py
@@ -14,7 +14,11 @@ def test_research_data(research_client: TestClient):
     assert len(data) == 2
     for item in data:
         assert item["user_question_1"] == "lorem ipsum"
+        # for user question 2, the answer is "other" which is the additional_option for this question,
+        # so we get the additional_answer here instead of the answer:
+        assert item["user_question_2"] == "dolor sit"
         assert item["child_question_1"] == "a"
+        assert item["child_question_2"] == "apple"
         assert "milestone_id_1" in item
 
 

--- a/mondey_backend/tests/routers/test_users.py
+++ b/mondey_backend/tests/routers/test_users.py
@@ -334,7 +334,7 @@ def test_get_current_child_answers_works(user_client: TestClient):
         "2": {
             "answer": "other",
             "question_id": 2,
-            "additional_answer": "dolor sit",
+            "additional_answer": "apple",
         },
     }
 


### PR DESCRIPTION
- if the `answer` to a question is the `additional_option` from the question
  - the user entered a free text answer `additional_answer`
  - this `additional_answer` is now used instead of `answer` in the research/data endpoint
- resolves #308