### PR TITLE
Allow selection of multiple milestones in research page

### DIFF
--- a/frontend/src/lib/translations.ts
+++ b/frontend/src/lib/translations.ts
@@ -144,7 +144,7 @@ export const translationIds = {
 		selectColumns: "Spalten auswählen",
 		milestone: "Meilenstein",
 		error: "Ein Fehler ist aufgetreten. Bitte versuchen sie es später erneut.",
-		milestoneId: "Meilenstein-ID",
+		milestones: "Meilensteine",
 		groupbyOptional: "Gruppieren nach (optional)",
 	},
 	registration: {


### PR DESCRIPTION
- milestone selection is now a multiselect
- refactor worker
  - all selected milestones are now concatenated before groupby
  - separate init and update messages
- use milestone and groupby names throughout (including in generated CSV file, filename, and web page)
- resolves #325