### PR TITLE
Fix bug causing duplicate test user accounts if the user double clicked. Issue #329

### DIFF
--- a/frontend/src/lib/components/FrontPageAbout.svelte
+++ b/frontend/src/lib/components/FrontPageAbout.svelte
@@ -14,21 +14,21 @@ import { Button, Card } from "flowbite-svelte";
 
 let showAlert = $state(false);
 let alertMessage = $state(i18n.tr.registration.alertMessageError);
-
-let testAccountData: UserCreate = {
-	email: `${((Math.random() + 0.1) * 100000000).toString()}tester@testaccount.com`,
-	password: ((Math.random() + 0.1) * 100000000).toString(), // random 8 digit or more password
-	is_active: true,
-	research_group_id: 0,
-};
-let registerRequestTestAccountData: RegisterRegisterData = {
-	body: testAccountData,
-};
+let registerTestUserButtonDisabled = $state(false);
 
 const registerTestUser = async () => {
-	console.log("Calling register...");
+	let testAccountData: UserCreate = {
+		email: `${((Math.random() + 0.1) * 100000000).toString()}tester@testaccount.com`,
+		password: ((Math.random() + 0.1) * 100000000).toString(), // random 8 digit or more password
+		is_active: true,
+		research_group_id: 0,
+	};
+	let registerRequestTestAccountData: RegisterRegisterData = {
+		body: testAccountData,
+	};
+	registerTestUserButtonDisabled = true;
 	const result = await registerRegister(registerRequestTestAccountData);
-	console.log("Registered..");
+
 	if (result.error) {
 		alertMessage = `${i18n.tr.registration.alertMessageError}: ${result.error.detail}`;
 		showAlert = true;
@@ -75,7 +75,9 @@ const registerTestUser = async () => {
       <p class="mb-3 font-normal max-w-prose text-gray-700 dark:text-gray-400">{i18n.tr.frontpageAbout.summary1}</p>
       <p class="mb-3 font-normal max-w-prose text-gray-700 dark:text-gray-400">{i18n.tr.frontpageAbout.summary2}</p>
 
-        <button class="btn-primary" data-testid="anonymousLogin" onclick={registerTestUser}>{i18n.tr.frontpageAbout.tryDemo}</button>
+        <button disabled={registerTestUserButtonDisabled} class="btn-primary" data-testid="anonymousLogin" onclick={registerTestUser}>
+          {i18n.tr.frontpageAbout.tryDemo}
+        </button>
       </div>
     </Card>
   </div>


### PR DESCRIPTION
This closes #329 by configuring the test data on click rather than once per page load, and disables the button as a rudimentary way to prevent account creation spam.