### PR TITLE
Don't provide feedback if too few datapoints, and use 0-3 scale for s…

### DIFF
--- a/frontend/src/lib/components/DataDisplay/PlotLines.svelte
+++ b/frontend/src/lib/components/DataDisplay/PlotLines.svelte
@@ -42,10 +42,10 @@ onMount(() => {
 				label: `${i18n.tr.admin.age} (m)`,
 				tickValues: [1, 2, 3, 4, 5, 6, 9, 12, 16, 24, 36, 48, 60, 72],
 			}),
-			yAxis: new Axis({ label: `${i18n.tr.admin.averageScore} (1-4)` }),
+			yAxis: new Axis({ label: `${i18n.tr.admin.averageScore} (0-3)` }),
 			xScale: Scale.scalePow().exponent(0.5),
 			xDomain: [1, 72],
-			yDomain: [1, 4],
+			yDomain: [0, 3],
 		},
 		plot_data.data,
 	);

--- a/frontend/src/lib/components/DataDisplay/PlotScoreAge.svelte
+++ b/frontend/src/lib/components/DataDisplay/PlotScoreAge.svelte
@@ -36,14 +36,16 @@ onMount(() => {
 					color: "#000000",
 				}),
 			],
-			xAxis: new Axis({
+			xAxis: new Axis<MilestoneAgeScore>({
 				label: `${i18n.tr.admin.age} (m)`,
 				tickValues: [0, 1, 2, 3, 4, 5, 6, 9, 12, 16, 24, 36, 48, 60, 72],
 			}),
-			yAxis: new Axis({ label: `${i18n.tr.admin.averageScore} (1-4)` }),
+			yAxis: new Axis<MilestoneAgeScore>({
+				label: `${i18n.tr.admin.averageScore} (0-3)`,
+			}),
 			xScale: Scale.scalePow().exponent(0.5),
 			xDomain: [0, 72],
-			yDomain: [1, 4],
+			yDomain: [0, 3],
 		},
 		scores,
 	);

--- a/mondey_backend/src/mondey_backend/routers/scores.py
+++ b/mondey_backend/src/mondey_backend/routers/scores.py
@@ -46,16 +46,17 @@ def compute_feedback_simple(
     Returns
     -------
     int
+        -2 if there is insufficient data to provide feedback (trafficlight: invalid)
         -1 if score <= avg - 2 * stddev (trafficlight: red)
         0 if avg - 2 * stddev < score <= avg - stddev (trafficlight: yellow)
-        1if score > avg - stddev (trafficlight: green)
+        1 if score > avg - stddev (trafficlight: green)
     """
 
     def leq(val: float, lim: float) -> bool:
         return val < lim or bool(np.isclose(val, lim))
 
-    if stat.avg_score < 1e-2 and stat.stddev_score < 1e-2:
-        # statistics has no data
+    if stat.stddev_score < 0:
+        # negative stddev indicates insufficient data so we cannot provide feedback
         return TrafficLight.invalid.value
 
     if stat.stddev_score < 1e-2:
@@ -136,7 +137,7 @@ def compute_milestonegroup_feedback_summary(
                     )
             # extract the answers for the current milestone group
             group_answers = [
-                answer.answer + 1
+                answer.answer
                 for answer in answersession.answers.values()
                 if answer.milestone_group_id == group
             ]
@@ -209,7 +210,7 @@ def compute_milestonegroup_feedback_detailed(
                         f"   score: {i}, {score.count}, {score.avg_score}, {score.stddev_score}"
                     )
             feedback[answer.milestone_group_id][cast(int, answer.milestone_id)] = (
-                compute_feedback_simple(stats.scores[age], answer.answer + 1)
+                compute_feedback_simple(stats.scores[age], answer.answer)
             )
 
     logger.debug(f" detailed feedback: {feedback}")

--- a/mondey_backend/tests/conftest.py
+++ b/mondey_backend/tests/conftest.py
@@ -371,9 +371,9 @@ def session(children: list[dict], monkeypatch: pytest.MonkeyPatch):
                     age=age,
                     milestone_id=1,
                     count=1 if age == 8 else 0,
-                    avg_score=2.0 if age == 8 else 0,
+                    avg_score=1.0 if age == 8 else 0,
                     stddev_score=0.0,
-                    expected_score=3 if age >= 8 else 1,
+                    expected_score=2 if age >= 8 else 0,
                 )
             )
 
@@ -395,9 +395,9 @@ def session(children: list[dict], monkeypatch: pytest.MonkeyPatch):
                     age=age,
                     milestone_id=2,
                     count=1 if age == 8 else 0,
-                    avg_score=1.0 if age == 8 else 0,
+                    avg_score=0.0 if age == 8 else 0,
                     stddev_score=0.0,
-                    expected_score=3 if age >= 8 else 1,
+                    expected_score=2 if age >= 8 else 0,
                 )
             )
 
@@ -418,7 +418,7 @@ def session(children: list[dict], monkeypatch: pytest.MonkeyPatch):
                     age=age,
                     milestone_group_id=1,
                     count=2 if age == 8 else 0,
-                    avg_score=1.5 if age == 8 else 0.0,
+                    avg_score=0.5 if age == 8 else 0.0,
                     stddev_score=0.5 if age == 8 else 0.0,
                 )
             )

--- a/mondey_backend/tests/routers/admin_routers/test_admin_milestones.py
+++ b/mondey_backend/tests/routers/admin_routers/test_admin_milestones.py
@@ -236,7 +236,7 @@ def test_get_milestone_age_scores(admin_client_stat: TestClient):
     assert response.json()["scores"][7]["stddev_score"] == pytest.approx(0.0)
     assert response.json()["scores"][7]["count"] == 0
 
-    assert response.json()["scores"][8]["avg_score"] == pytest.approx(2.0)
+    assert response.json()["scores"][8]["avg_score"] == pytest.approx(1.0)
     assert response.json()["scores"][8]["stddev_score"] == pytest.approx(0.0)
     assert response.json()["scores"][8]["count"] == 1
 

--- a/mondey_backend/tests/utils/test_scores.py
+++ b/mondey_backend/tests/utils/test_scores.py
@@ -49,22 +49,22 @@ async def test_compute_summary_milestonegroup_feedback_for_answersession_with_re
     statistics_session, user_session
 ):
     child_age = 8
-    # existing statistics for milestonegroup 1 at age 8 months: [1,2] -> mean = 1.5 +/- 0.5
+    # existing statistics for milestonegroup 1 at age 8 months: [0,1] -> mean = 0.5 +/- 0.5
     statistics = statistics_session.exec(
         select(MilestoneGroupAgeScoreCollection).where(
             MilestoneGroupAgeScoreCollection.milestone_group_id == 1
         )
     ).all()
     assert len(statistics) == 1
-    assert statistics[0].scores[child_age].avg_score == pytest.approx(1.5, abs=0.001)
+    assert statistics[0].scores[child_age].avg_score == pytest.approx(0.5, abs=0.001)
     assert statistics[0].scores[child_age].stddev_score == pytest.approx(0.5, abs=0.001)
-    # answer session 1 scores: [1, 2] -> mean 1.5 -> green
+    # answer session 1 scores: [0, 1] -> mean 0.5 -> green
     feedback = compute_milestonegroup_feedback_summary(
         statistics_session, child_id=1, answersession_id=1
     )
     assert feedback[1] == TrafficLight.green.value
     assert len(feedback) == 1
-    # answer session 2 scores: [3, 4] -> mean 3.5 -> green
+    # answer session 2 scores: [2, 3] -> mean 2.5 -> green
     feedback = compute_milestonegroup_feedback_summary(
         statistics_session, child_id=1, answersession_id=2
     )
@@ -76,7 +76,7 @@ async def test_compute_summary_milestonegroup_feedback_for_answersession_with_re
             user_session,
             incremental_update=update_existing_statistics,
         )
-        # updated stats for milestonegroup 1 at age 8 months: [1,2,3,4,3,4] -> mean = 2.83333 +/- ~1.2
+        # updated stats for milestonegroup 1 at age 8 months: [0,1,2,3,2,3] -> mean = 1.83333 +/- ~1.2
         statistics = statistics_session.exec(
             select(MilestoneGroupAgeScoreCollection).where(
                 MilestoneGroupAgeScoreCollection.milestone_group_id == 1
@@ -84,18 +84,18 @@ async def test_compute_summary_milestonegroup_feedback_for_answersession_with_re
         ).all()
         assert len(statistics) == 1
         assert statistics[0].scores[child_age].avg_score == pytest.approx(
-            2.83333, abs=0.001
+            1.83333, abs=0.001
         )
         assert statistics[0].scores[child_age].stddev_score == pytest.approx(
             1.2, abs=0.1
         )
-        # answer session 1 score 1.5 -> yellow
+        # answer session 1 score 0.5 -> yellow
         feedback = compute_milestonegroup_feedback_summary(
             statistics_session, child_id=1, answersession_id=1
         )
         assert feedback[1] == TrafficLight.yellow.value
         assert len(feedback) == 1
-        # answer session 2 score 3.5 remain green
+        # answer session 2 score 2.5 remain green
         feedback = compute_milestonegroup_feedback_summary(
             statistics_session, child_id=1, answersession_id=2
         )
@@ -134,9 +134,9 @@ async def test_compute_detailed_milestonegroup_feedback_for_answersession_with_r
     )
     assert len(feedback) == 1
     assert len(feedback[1]) == 2
-    # milestone 1: score 2, mean = 3.33+/-1.2 -> yellow
+    # milestone 1: score 2, mean = 2.33+/-1.2 -> yellow
     assert feedback[1][1] == TrafficLight.yellow.value
-    # milestone 2: score 1, mean = 2.33+/-1.2 -> yello
+    # milestone 2: score 1, mean = 1.33+/-1.2 -> yellow
     assert feedback[1][2] == TrafficLight.yellow.value
 
 


### PR DESCRIPTION
…cores

- don't provide feeback if too few datapoints
  - add `min_num_samples` parameter to `_finalize_statistics`
    - if there are fewer than this number of samples, we set the standard deviation to -1
    - currently this is set to 2 for testing so we see some feedback with the current data
    - can increase this later in production
  - compute_feedback_simple
    - now returns (existing) `invalid` trafficlight if standard deviation is negative
  - resolves #336
- use 0-3 for answer score scale
  - reduces possibility of bugs due to converting between 0-3 and 1-4 scales in various places
  - NOTE: after merging this we need to call the `/admin/update-stats/false` endpoint to update all statistics in the database
  - resolves #271