### PR TITLE
Remove paragraph from milestones + Make 2-3 columns appear depending on screen size

### DIFF
--- a/frontend/src/lib/components/DataDisplay/GalleryDisplay.svelte
+++ b/frontend/src/lib/components/DataDisplay/GalleryDisplay.svelte
@@ -70,8 +70,8 @@ let filteredComponentProps = $derived(
 	{/if}
 
 	{#if withSearch}
-		<form class="m-2 w-full rounded p-4">
-			{#if searchData.length > 1}
+		<form class="m-2 w-full rounded p-4 {searchData.length > 1 ? 'flex' : ''}">
+		{#if searchData.length > 1}
 				<!-- after example: https://flowbite-svelte.com/docs/forms/search-input#Search_with_dropdown -->
 				<div class="relative">
 					<Button
@@ -115,7 +115,7 @@ let filteredComponentProps = $derived(
 	{/if}
 
 	<div
-		class="grid w-full grid-cols-1 justify-center gap-8 p-4 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
+		class="grid w-full grid-cols-1 justify-center gap-8 p-4 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3"
 	>
 		{#each filteredItems as item, index}
 			<svelte:component

--- a/frontend/src/routes/userLand/milestone/overview/+page.svelte
+++ b/frontend/src/routes/userLand/milestone/overview/+page.svelte
@@ -133,7 +133,7 @@ async function setup(): Promise<void> {
 				return {
 					header: item?.text?.[i18n.locale]?.title ?? "",
 					complete: complete,
-					summary: item?.text?.[i18n.locale]?.desc ?? "",
+					summary: "",
 					events: {
 						onclick: () => {
 							contentStore.milestone = item.id;


### PR DESCRIPTION
 Yes we said 4 was okay on big screens, but I think the breakpoint for big is much smaller than we expect - it's essentially not much bigger than a laptop screen). Plus fix the search menu being broken for cases where there is search data.