### PR TITLE
Fix bug in stats update caused by negative age child

### DIFF
--- a/mondey_backend/src/mondey_backend/logging.py
+++ b/mondey_backend/src/mondey_backend/logging.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger("mondey_backend")

--- a/mondey_backend/src/mondey_backend/main.py
+++ b/mondey_backend/src/mondey_backend/main.py
@@ -19,6 +19,7 @@ from .databases.mondey import create_mondey_db_and_tables
 from .databases.mondey import engine as mondey_engine
 from .databases.users import create_user_db_and_tables
 from .databases.users import engine as users_engine
+from .logging import logger
 from .routers import admin
 from .routers import auth
 from .routers import milestones
@@ -107,7 +108,6 @@ def main():
         format="%(asctime)s.%(msecs)03d :: %(levelname)s :: %(name)s :: %(funcName)s :: %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
     )
-    logger = logging.getLogger(__name__)
     if not app_settings.DATABASE_PATH:
         logger.warning(
             "No database path set. Using temporary directory, all data will be lost when server is stopped."

--- a/mondey_backend/src/mondey_backend/routers/scores.py
+++ b/mondey_backend/src/mondey_backend/routers/scores.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from collections import defaultdict
 from enum import Enum
 
@@ -8,6 +7,7 @@ import numpy as np
 from sqlmodel import select
 
 from ..dependencies import SessionDep
+from ..logging import logger
 from ..models.milestones import Milestone
 from ..models.milestones import MilestoneAgeScore
 from ..models.milestones import MilestoneAgeScoreCollection
@@ -103,7 +103,6 @@ def compute_milestonegroup_feedback_summary(
     dict[int, int]
         Dictionary of milestonegroup_id -> feedback
     """
-    logger = logging.getLogger(__name__)
     logger.debug("compute_milestonegroup_feedback_summary")
     logger.debug(
         f"  answersession id: {answersession.id}, created_at: {answersession.created_at}"
@@ -171,8 +170,6 @@ def compute_milestonegroup_feedback_detailed(
     dict[int, dict[int, int]]
         Dictionary of milestonegroup_id -> [milestone_id -> feedback]
     """
-    logger = logging.getLogger(__name__)
-
     logger.debug("compute_milestonegroup_feedback_detailed")
     logger.debug(
         f"  answersession id: {answersession.id} created_at: {answersession.created_at}"

--- a/mondey_backend/src/mondey_backend/routers/users.py
+++ b/mondey_backend/src/mondey_backend/routers/users.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from datetime import datetime
 
 import numpy as np
@@ -228,11 +227,7 @@ def create_router() -> APIRouter:
         milestone_answer.answer = answer.answer
         session.commit()
         session.refresh(milestone_answer_session)
-        logging.warning(milestone_answer_session)
         if all(a.answer >= 0 for a in milestone_answer_session.answers.values()):
-            logging.warning(
-                sum(a.answer >= 0 for a in milestone_answer_session.answers.values())
-            )
             milestone_answer_session.expired = True
             milestone_answer_session.completed = True
             session.add(milestone_answer_session)

--- a/mondey_backend/src/mondey_backend/routers/utils.py
+++ b/mondey_backend/src/mondey_backend/routers/utils.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import datetime
-import logging
 import pathlib
 from collections.abc import Iterable
 from collections.abc import Sequence
@@ -20,6 +19,7 @@ from sqlmodel import select
 from webp import WebPPreset
 
 from ..dependencies import SessionDep
+from ..logging import logger
 from ..models.children import Child
 from ..models.milestones import Milestone
 from ..models.milestones import MilestoneAdmin
@@ -60,7 +60,7 @@ def write_image_file(file: UploadFile, filename: pathlib.Path | str):
                 img, filename, preset=WebPPreset.PHOTO, quality=image_quality
             )
     except Exception as e:
-        logging.exception(e)
+        logger.exception(e)
         raise HTTPException(status_code=404, detail="Error saving uploaded file") from e
     finally:
         file.file.close()
@@ -284,7 +284,7 @@ def get_answer_session_child_ages_in_months(
     }
 
 
-def _get_expected_age_from_scores(scores: np.ndarray, count: np.ndarray) -> int:
+def get_expected_age_from_scores(scores: np.ndarray, count: np.ndarray) -> int:
     """
     Returns the expected age for a milestone based on the average scores for each child age.
     :param scores: the average score for each age, where the index in the array is the age in months


### PR DESCRIPTION
- ignore the answer if the child has a negative age
- also only calculate agescorecollections for ages <= 72
  - note: do `drop table milestoneagescorecollection; drop table milestonegroupagescorecollection;` before running this commit
- resolves #371
    
    Also centralise logging, remove some leftover debugging logging output