### PR TITLE
Improve navigation errors

### DIFF
--- a/frontend/src/lib/components/DataDisplay/CardDisplay.svelte
+++ b/frontend/src/lib/components/DataDisplay/CardDisplay.svelte
@@ -11,6 +11,7 @@ let {
 	color = undefined,
 	cardClasses = "",
 	titleClasses = "",
+	disabled = false,
 	onclick,
 	children,
 }: {
@@ -21,6 +22,7 @@ let {
 	onclick: () => void;
 	cardClasses?: string;
 	titleClasses?: string;
+	disabled?: boolean;
 	children?: Snippet;
 } = $props();
 
@@ -28,12 +30,12 @@ let textColor = $derived(isDark(color) ? "text-white" : "text-black");
 </script>
 
 <Card
-        class={`hover:transition-color flex flex-col h-full cursor-pointer hover:scale-105 child-card hover:cursor-pointer mr-2 max-w-prose ${cardClasses}`}
+        class={`${disabled ? 'opacity-30' : 'cursor-pointer hover:scale-105 hover:transition-color hover:cursor-pointer'} flex flex-col h-full mr-2 max-w-prose ${cardClasses}`}
         style={color ? `background-color: ${color}` : ""}
         horizontal={false}
         img={image}
         imgClass="max-md:hidden object-scale-down"
-        on:click={onclick}
+        on:click={!disabled ? onclick : () => {}}
 >
         {#if title}
             <div>
@@ -52,6 +54,8 @@ let textColor = $derived(isDark(color) ? "text-white" : "text-black");
         </div>
 
         <div class={`mt-auto pt-4 flex flex-col ${color ? textColor : ''}`}>
-            {@render children?.()}
+            {#if !disabled}
+                {@render children?.()}
+            {/if}
         </div>
 </Card>

--- a/frontend/src/lib/translations.ts
+++ b/frontend/src/lib/translations.ts
@@ -29,8 +29,6 @@ export const translationIds = {
 		autoNext: "Automatisch weiter",
 		groupOverviewLabel: "Übersicht Meilensteingruppen",
 		alertMessageRetrieving: "Fehler beim Abrufen der Meilensteine",
-		alertMessageNoRelevantMilestones:
-			"Sie mussen zuerst Meilensteine hinzufügen, die für das Alter des Kindes +/- 6 Monaten relevant sind. Bitte versuchen sie es erneut, nachdem Meilensteine hinzugefügt wurden",
 		noRelevantMilestones:
 			"Es gibt keine Meilensteine, die für das Alter des Kindes +/- 6 Monate relevant sind",
 		alertMessageError: "Ein Fehler ist aufgetreten",

--- a/frontend/src/routes/userLand/children/feedback/+page.svelte
+++ b/frontend/src/routes/userLand/children/feedback/+page.svelte
@@ -59,16 +59,16 @@ const breakpoints = {
 	xl: 1280,
 	"2xl": 1536,
 };
-let windowidth = $state(0);
+let windowWidth = $state(0);
 
-// adjustment of displayed data based on current windowwidth
+// adjustment of displayed data based on current window width
 onMount(() => {
 	// Set initial width
-	windowidth = window.innerWidth;
+	windowWidth = window.innerWidth;
 
 	// Add event listener
 	const handleResize = () => {
-		windowidth = window.innerWidth;
+		windowWidth = window.innerWidth;
 	};
 
 	window.addEventListener("resize", handleResize);
@@ -80,19 +80,19 @@ onMount(() => {
 });
 
 let numShownAnswersessions = $derived.by(() => {
-	if (windowidth >= breakpoints["2xl"]) {
+	if (windowWidth >= breakpoints["2xl"]) {
 		return 10;
 	}
-	if (windowidth >= breakpoints.xl) {
+	if (windowWidth >= breakpoints.xl) {
 		return 8;
 	}
-	if (windowidth >= breakpoints.lg) {
+	if (windowWidth >= breakpoints.lg) {
 		return 6;
 	}
-	if (windowidth >= breakpoints.md) {
+	if (windowWidth >= breakpoints.md) {
 		return 4;
 	}
-	if (windowidth >= breakpoints.sm) {
+	if (windowWidth >= breakpoints.sm) {
 		return 3;
 	}
 	return 2;
@@ -116,7 +116,6 @@ let showHelp = $state(false);
 
 // promises to load the data and steer page loading
 let sessionPromise = $state(loadAnswersessions());
-let stillLoading = $state(true);
 
 // data defining the legend for the feedback
 let milestonePresentation = [
@@ -181,18 +180,13 @@ async function loadAnswersessions(): Promise<void> {
 	}
 	await currentChild.load_data();
 	if (currentChild.id === null || user.id === null) {
-		alertStore.showAlert(
-			i18n.tr.childData.alertMessageTitle,
-			i18n.tr.childData.alertMessageError,
-			true,
-			false,
-		);
+		await goto("/userLand/children");
 		return;
 	}
 
 	// load all answersessions initially
 	const responseAnswerSessions = await getCompletedMilestoneAnswerSessions({
-		path: { child_id: currentChild.id as number },
+		path: { child_id: currentChild.id },
 	});
 
 	if (responseAnswerSessions.error) {
@@ -205,7 +199,9 @@ async function loadAnswersessions(): Promise<void> {
 		return;
 	}
 	answerSessions = responseAnswerSessions.data;
-	await loadData(relevant_sessionkeys[0]);
+	if (Object.keys(answerSessions).length > 0) {
+		await loadData(relevant_sessionkeys[0]);
+	}
 }
 
 /**

--- a/frontend/src/routes/userLand/children/registration/+page.svelte
+++ b/frontend/src/routes/userLand/children/registration/+page.svelte
@@ -29,24 +29,13 @@ import { i18n } from "$lib/i18n.svelte";
 import { alertStore } from "$lib/stores/alertStore.svelte";
 import { currentChild } from "$lib/stores/childrenStore.svelte";
 import { preventDefault } from "$lib/util";
-import {
-	Button,
-	Card,
-	Heading,
-	Hr,
-	Input,
-	Spinner,
-	Tooltip,
-} from "flowbite-svelte";
+import { Button, Card, Heading, Spinner, Tooltip } from "flowbite-svelte";
 import {
 	ChartLineUpOutline,
 	CheckCircleOutline,
 	ClipboardCheckOutline,
 	FlagOutline,
 	GridPlusSolid,
-	PenOutline,
-	QuestionCircleSolid,
-	TrashBinOutline,
 	UserSettingsOutline,
 } from "flowbite-svelte-icons";
 // questions and answers about child that are not part of the child object

--- a/frontend/src/routes/userLand/dataInput/+page.svelte
+++ b/frontend/src/routes/userLand/dataInput/+page.svelte
@@ -44,7 +44,7 @@ async function setup() {
 	if (userQuestions.error || userQuestions.data === undefined) {
 		console.log(
 			"Error when getting userquestions: ",
-			userQuestions.error.detail,
+			userQuestions.error?.detail,
 		);
 		alertStore.showAlert(
 			i18n.tr.userData.alertMessageTitle,

--- a/frontend/src/routes/userLand/milestone/+page.svelte
+++ b/frontend/src/routes/userLand/milestone/+page.svelte
@@ -118,6 +118,7 @@ function selectAnswer(answer: number) {
 async function setup() {
 	if (currentChild.id === null || currentChild.id === undefined) {
 		console.log("No current child");
+		await goto("/userLand/children");
 		return;
 	}
 

--- a/frontend/src/routes/userLand/milestone/group/+page.svelte
+++ b/frontend/src/routes/userLand/milestone/group/+page.svelte
@@ -53,13 +53,8 @@ async function setup(): Promise<MilestoneGroupDisplayData[] | null> {
 
 	if (currentChild.id === null || currentChild.id === undefined) {
 		console.log("Error when retrieving child data");
-		alertStore.showAlert(
-			i18n.tr.milestone.alertMessageError,
-			i18n.tr.childData.alertMessageRetrieving,
-			true,
-			false,
-		);
-		return null;
+		await goto("/userLand/children");
+		return;
 	}
 
 	const milestoneGroups = await getMilestoneGroups({

--- a/frontend/src/routes/userLand/milestone/group/+page.svelte
+++ b/frontend/src/routes/userLand/milestone/group/+page.svelte
@@ -46,6 +46,7 @@ type MilestoneGroupDisplayData = {
 	text: string;
 	progress: number;
 	onclick: () => void;
+	disabled: boolean;
 };
 
 async function setup(): Promise<MilestoneGroupDisplayData[] | null> {
@@ -92,6 +93,7 @@ async function setup(): Promise<MilestoneGroupDisplayData[] | null> {
 			title: item?.text?.[i18n.locale]?.title ?? "",
 			text: item?.text?.[i18n.locale]?.desc ?? "",
 			progress: computeProgress(item.milestones, answerSession.data),
+			disabled: item.milestones.length === 0,
 			onclick: () => {
 				goto("/userLand/milestone/overview");
 				contentStore.milestoneGroup = item.id;
@@ -142,7 +144,8 @@ let searchTerm = $state("");
                         <CardDisplay title={milestoneGroup.title}
                                      text={milestoneGroup.text}
                                      onclick={milestoneGroup.onclick}
-                                     cardClasses="dark:text-white text-white bg-milestone-700 dark:bg-milestone-900 hover:bg-milestone-800 dark:hover:bg-milestone-700"
+                                     disabled={milestoneGroup.disabled}
+                                     cardClasses={`dark:text-white text-white bg-milestone-700 dark:bg-milestone-900 ${milestoneGroup.disabled ? '' : 'hover:bg-milestone-800 dark:hover:bg-milestone-700'}`}
                         >
                             <Progress progress={milestoneGroup.progress}/>
                         </CardDisplay>

--- a/frontend/src/routes/userLand/milestone/overview/+page.svelte
+++ b/frontend/src/routes/userLand/milestone/overview/+page.svelte
@@ -20,6 +20,10 @@ import {
 } from "flowbite-svelte-icons";
 
 async function setup(): Promise<MilestoneAnswerSessionPublic | null> {
+	if (!currentChild?.id) {
+		await goto("/userLand/children");
+		return null;
+	}
 	if (
 		!contentStore.milestoneGroupData?.milestones ||
 		contentStore.milestoneGroupData?.milestones?.length === 0
@@ -28,10 +32,6 @@ async function setup(): Promise<MilestoneAnswerSessionPublic | null> {
 			"Error when retrieving milestone groups ",
 			contentStore.milestoneGroupData,
 		);
-		await goto("/userLand/children");
-		return null;
-	}
-	if (!currentChild?.id) {
 		await goto("/userLand/children");
 		return null;
 	}

--- a/frontend/src/routes/userLand/milestone/overview/+page.svelte
+++ b/frontend/src/routes/userLand/milestone/overview/+page.svelte
@@ -21,19 +21,18 @@ import {
 
 async function setup(): Promise<MilestoneAnswerSessionPublic | null> {
 	if (
-		!contentStore.milestoneGroupData.milestones ||
-		contentStore.milestoneGroupData.milestones.length === 0
+		!contentStore.milestoneGroupData?.milestones ||
+		contentStore.milestoneGroupData?.milestones?.length === 0
 	) {
-		// todo: should probably redirect e.g. to login here rather than show an error
 		console.log(
 			"Error when retrieving milestone groups ",
 			contentStore.milestoneGroupData,
 		);
-		const message =
-			contentStore.milestoneGroupData.milestones.length === 0
-				? i18n.tr.milestone.alertMessageNoRelevantMilestones
-				: i18n.tr.milestone.alertMessageRetrieving;
-		alertStore.showAlert(i18n.tr.milestone.alertMessageError, message, true);
+		await goto("/userLand/children");
+		return null;
+	}
+	if (!currentChild?.id) {
+		await goto("/userLand/children");
 		return null;
 	}
 	await currentChild.load_data();
@@ -73,7 +72,7 @@ const breadcrumbdata: any[] = [
 		symbol: RectangleListOutline,
 	},
 	{
-		label: contentStore.milestoneGroupData.text[i18n.locale].title,
+		label: contentStore.milestoneGroupData?.text?.[i18n.locale]?.title,
 		onclick: () => {
 			goto("/userLand/milestone/overview");
 		},


### PR DESCRIPTION
- /children/feedback
  - don't display error if there are no answer sessions yet
- /milestone/* and /children/*
  - redirect to /children if necessary data is missing (e.g. if user refreshed)
- resolves various cases where opening a saved link or refreshing the page results in a broken website state
- resolves #256