### PR TITLE
Increase nginx proxy timeout for /api reads

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -68,5 +68,7 @@ server {
       proxy_set_header Host $http_host;
       proxy_redirect off;
       proxy_pass http://backend:80;
+      # increase timeout as update stats API call can take a long time to complete:
+      proxy_read_timeout 600;
    }
 }


### PR DESCRIPTION
- increase the read timeout to 10 minutes to allow for potentially slow update stats endpoint call
- resolves #394