### PR TITLE
Add daily database backups

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,6 @@ services:
     shm_size: 128mb
     volumes:
       - ${POSTGRES_DATA_PATH_MONDEY:-./db/mondey}:/var/lib/postgresql/data
-      - ./db:/db
     environment:
       - POSTGRES_USER=${DATABASE_USER:-postgres}
       - POSTGRES_PASSWORD=${DATABASE_PASSWORD:-}
@@ -77,7 +76,6 @@ services:
     shm_size: 128mb
     volumes:
       - ${POSTGRES_DATA_PATH_USER:-./db/users}:/var/lib/postgresql/data
-      - ./db:/db
     environment:
       - POSTGRES_USER=${DATABASE_USER:-postgres}
       - POSTGRES_PASSWORD=${DATABASE_PASSWORD:-}
@@ -104,3 +102,45 @@ services:
       options:
         max-size: 20m
         max-file: 3
+  mondeydb-backup:
+    image: prodrigestivill/postgres-backup-local:17-alpine
+    restart: always
+    volumes:
+        - ${POSTGRES_DATA_PATH_MONDEY_BACKUPS:-./db_backups/mondey}:/backups
+    links:
+        - mondeydb
+    depends_on:
+        - mondeydb
+    environment:
+        - POSTGRES_HOST=mondeydb
+        - POSTGRES_DB=mondey
+        - POSTGRES_USER=postgres
+        - POSTGRES_PASSWORD=${DATABASE_PASSWORD:-}
+        - POSTGRES_EXTRA_OPTS=--compress=zstd --clean
+        - SCHEDULE=@daily
+        - BACKUP_ON_START=TRUE
+        - BACKUP_KEEP_DAYS=7
+        - BACKUP_KEEP_WEEKS=4
+        - BACKUP_KEEP_MONTHS=6
+        - HEALTHCHECK_PORT=8080
+  usersdb-backup:
+    image: prodrigestivill/postgres-backup-local:17-alpine
+    restart: always
+    volumes:
+        - ${POSTGRES_DATA_PATH_USER_BACKUPS:-./db_backups/users}:/backups
+    links:
+        - usersdb
+    depends_on:
+        - usersdb
+    environment:
+        - POSTGRES_HOST=usersdb
+        - POSTGRES_DB=users
+        - POSTGRES_USER=postgres
+        - POSTGRES_PASSWORD=${DATABASE_PASSWORD:-}
+        - POSTGRES_EXTRA_OPTS=--compress=zstd --clean
+        - SCHEDULE=@daily
+        - BACKUP_ON_START=TRUE
+        - BACKUP_KEEP_DAYS=7
+        - BACKUP_KEEP_WEEKS=4
+        - BACKUP_KEEP_MONTHS=6
+        - HEALTHCHECK_PORT=8080

--- a/mondey_backend/src/mondey_backend/models/questions.py
+++ b/mondey_backend/src/mondey_backend/models/questions.py
@@ -5,10 +5,9 @@ from sqlmodel import Field
 from sqlmodel import SQLModel
 
 from .utils import back_populates
-
-# Different format to dict-relationship
 from .utils import dict_relationship
 from .utils import fixed_length_string_field
+from .utils import list_relationship
 
 
 # user questions
@@ -66,9 +65,7 @@ class UserQuestionText(QuestionTextBase, table=True):
 class UserQuestion(Question, table=True):
     id: int | None = Field(default=None, primary_key=True)
     text: Mapped[dict[str, UserQuestionText]] = dict_relationship(key="lang_id")
-    answers: Mapped[list[UserAnswer]] = back_populates(
-        "question", cascade="all, delete-orphan"
-    )
+    answers: Mapped[list[UserAnswer]] = list_relationship("question")
     name: str = ""
 
 
@@ -102,9 +99,7 @@ class ChildQuestionText(QuestionTextBase, table=True):
 class ChildQuestion(Question, table=True):
     id: int | None = Field(default=None, primary_key=True)
     text: Mapped[dict[str, ChildQuestionText]] = dict_relationship(key="lang_id")
-    answers: Mapped[list[ChildAnswer]] = back_populates(
-        "question", cascade="all, delete-orphan"
-    )
+    answers: Mapped[list[ChildAnswer]] = list_relationship("question")
     name: str = ""
 
 
@@ -116,7 +111,7 @@ class ChildQuestionAdmin(QuestionAdmin):
     text: dict[str, ChildQuestionText] = {}
 
 
-# Answers to user questions. Internal model and 'public' model exposed to the forntend app
+# Answers to user questions. Internal model and 'public' model exposed to the frontend app
 class AnswerBase(SQLModel):
     answer: str
     additional_answer: str | None

--- a/mondey_backend/src/mondey_backend/models/utils.py
+++ b/mondey_backend/src/mondey_backend/models/utils.py
@@ -26,6 +26,16 @@ def back_populates(name: str, **kwargs):
     return Relationship(sa_relationship=relationship(back_populates=name, **kwargs))
 
 
+def list_relationship(name: str, **kwargs):
+    return Relationship(
+        sa_relationship=relationship(
+            back_populates=name,
+            cascade="all, delete-orphan",
+            **kwargs,
+        )
+    )
+
+
 def dict_relationship(key: str):
     return Relationship(
         sa_relationship=relationship(

--- a/mondey_backend/src/mondey_backend/routers/utils.py
+++ b/mondey_backend/src/mondey_backend/routers/utils.py
@@ -173,9 +173,9 @@ def session_remaining_seconds(
 ) -> float:
     session_lifetime_days = 14
     return (
-        datetime.datetime.now()
+        milestone_answer_session.created_at
         + datetime.timedelta(days=session_lifetime_days)
-        - milestone_answer_session.created_at
+        - datetime.datetime.now()
     ).total_seconds()
 
 


### PR DESCRIPTION
- add docker-postgres-backup-local images to docker-compose
  - does daily local backups of the databases
  - periodically removes old backups
- document how to restore from one of these backups in DEPLOYMENT.md
- resolves 280

Also

- minor refactor of database models for clarity
  - add `list_relationship` for relationship with delete cascade
  - use this instead of `back_propagates` with delete cascade as additional kwargs
- fix bug in session_remaining_seconds calculation
  - it should go down as time goes by, not up!