### PR TITLE
Don't repeat milestones after they have been fully achieved

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -170,3 +170,12 @@ Notes on the (one-off) process used to migrate the sqlite databases to postgres 
   - `docker exec -it $(docker ps | grep usersdb | awk '{print $1}') bash`
   - `apk update && apk add pgloader`
   - `pgloader --with "data only" sqlite:///db/users.db pgsql://postgres@127.0.0.1/users`
+
+#### Modifying the database
+
+To modify the database, you can connect to the running postgres database in the `mondeydb` container and then enter an SQL command:
+
+```
+docker exec -it $(docker ps | grep mondeydb-1 | awk '{print $1}') bash
+psql -U postgres -d mondey
+```

--- a/frontend/src/lib/components/DataDisplay/GalleryDisplay.svelte
+++ b/frontend/src/lib/components/DataDisplay/GalleryDisplay.svelte
@@ -1,14 +1,16 @@
 <svelte:options runes={true}/>
 <script lang="ts">
 import { i18n } from "$lib/i18n.svelte";
-import { Search } from "flowbite-svelte";
+import { Checkbox, Search } from "flowbite-svelte";
 import { type Snippet } from "svelte";
 
 let {
 	searchTerm = $bindable(""),
+	showIncompleteOnly = $bindable(null),
 	children,
 }: {
-	searchTerm?: string;
+	searchTerm: string;
+	showIncompleteOnly?: null | boolean;
 	children?: Snippet;
 } = $props();
 </script>
@@ -20,6 +22,11 @@ let {
             placeholder={i18n.tr.search.namePlaceholder}
             size="lg"
     />
+    {#if showIncompleteOnly !== null}
+        <Checkbox bind:checked={showIncompleteOnly} class="my-2">
+            {i18n.tr.search.showIncompleteOnly}
+        </Checkbox>
+    {/if}
 </form>
 <div class="grid w-full grid-cols-1 justify-center p-2 gap-8 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3">
     {@render children?.()}

--- a/frontend/src/lib/translations.ts
+++ b/frontend/src/lib/translations.ts
@@ -95,6 +95,7 @@ export const translationIds = {
 		milestonePlaceholder: "Nach enthaltenem Meilenstein durchsuchen",
 		complete: "fertig",
 		incomplete: "unfertig",
+		showIncompleteOnly: "nur unvollständige anzeigen",
 	},
 	admin: {
 		close: "Schließen",

--- a/frontend/src/routes/userLand/admin/+page.svelte
+++ b/frontend/src/routes/userLand/admin/+page.svelte
@@ -15,7 +15,6 @@ import { alertStore } from "$lib/stores/alertStore.svelte";
 import { user } from "$lib/stores/userStore.svelte";
 import { TabItem, Tabs } from "flowbite-svelte";
 import {
-	AdjustmentsHorizontalOutline,
 	BadgeCheckOutline,
 	ClipboardListOutline,
 	DatabaseOutline,

--- a/frontend/src/routes/userLand/milestone/group/+page.svelte
+++ b/frontend/src/routes/userLand/milestone/group/+page.svelte
@@ -129,6 +129,7 @@ const breadcrumbdata: any[] = [
 
 let promise = $state(setup());
 let searchTerm = $state("");
+let showIncompleteOnly = $state(true);
 </script>
 
 {#await promise}
@@ -138,9 +139,9 @@ let searchTerm = $state("");
     {#if milestoneGroups}
         <div class="flex flex-col md:rounded-t-lg">
             <Breadcrumbs data={breadcrumbdata}/>
-            <GalleryDisplay bind:searchTerm={searchTerm}>
+            <GalleryDisplay bind:searchTerm={searchTerm} bind:showIncompleteOnly={showIncompleteOnly}>
                 {#each milestoneGroups as milestoneGroup}
-                    {#if milestoneGroup.title.toLowerCase().includes(searchTerm.toLowerCase())}
+                    {#if milestoneGroup.title.toLowerCase().includes(searchTerm.toLowerCase()) && !(showIncompleteOnly && (milestoneGroup.disabled || milestoneGroup.progress === 1.0))}
                         <CardDisplay title={milestoneGroup.title}
                                      text={milestoneGroup.text}
                                      onclick={milestoneGroup.onclick}

--- a/frontend/src/routes/userLand/milestone/overview/+page.svelte
+++ b/frontend/src/routes/userLand/milestone/overview/+page.svelte
@@ -53,6 +53,7 @@ async function setup(): Promise<MilestoneAnswerSessionPublic | null> {
 }
 
 let searchTerm = $state("");
+let showIncompleteOnly = $state(true);
 
 const promise = $state(setup());
 
@@ -86,11 +87,11 @@ const breadcrumbdata: any[] = [
 {:then answerSession}
     <div class="mx-auto flex flex-col md:rounded-t-lg">
         <Breadcrumbs data={breadcrumbdata}/>
-        <GalleryDisplay bind:searchTerm={searchTerm}>
+        <GalleryDisplay bind:searchTerm={searchTerm} bind:showIncompleteOnly={showIncompleteOnly}>
             {#each contentStore.milestoneGroupData.milestones as milestone, idx}
                 {@const title = milestone?.text?.[i18n.locale]?.title ?? ""}
                 {@const complete = (answerSession?.answers?.[`${milestone.id}`]?.answer ?? -1) >= 0}
-                {#if title.toLowerCase().includes(searchTerm.toLowerCase())}
+                {#if title.toLowerCase().includes(searchTerm.toLowerCase()) && !(showIncompleteOnly && complete)}
                     <CardDisplay {title}
                                  cardClasses="dark:text-white text-white bg-milestone-300 dark:bg-milestone-300 hover:bg-milestone-500 dark:hover:bg-milestone-500"
                                  titleClasses="text-center"

--- a/mondey_backend/tests/routers/test_users.py
+++ b/mondey_backend/tests/routers/test_users.py
@@ -447,8 +447,11 @@ def test_update_milestone_answer_no_current_answer_session(
     # check that we get a new answer session
     new_answer_session = user_client.get("/users/milestone-answers/2").json()
     assert new_answer_session["id"] == 101
+    # answers are initially set to -1
     assert new_answer_session["answers"]["3"]["answer"] == -1
     assert new_answer_session["answers"]["4"]["answer"] == -1
+    # except if that milestone was previously answered with a 3, in which case it is set to 3:
+    assert new_answer_session["answers"]["5"]["answer"] == 3
 
 
 def test_update_milestone_answer_update_existing_answer(user_client: TestClient):


### PR DESCRIPTION
- backend
  - when constructing a new milestone answer session
  - check if there is an existing completed answer session
  - if so, for each milestone, check if that milestone was fully achieved (score=3)
  - in this case, pre-fill the answer to 3 for this milestone
- frontend
  - add a checkbox "only display unanswered" to milestones / milestonegroups
  - when checked, only unanswered milestones / groups with unanswered milestones are displayed
  - when unchecked, all milestones displayed (previous behaviour)
- resolves #414