### PR TITLE
A local docker development version which runs the dev server

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,10 @@ These API interfaces are only temporarily public for convenience during developm
 ### Licensing
 
 The source code in this repository is distributed under [AGPL-3.0-or-later](LICENSE).
+
+## To run from local development:
+From this directory: `docker-compose -f docker-compose.dev.yml up --build`
+
+This will build a local set of containers. The frontend container will be mounting your code volume and running the command
+`pnpm run dev`, so via hot reload it will automatically trigger reacting to code changes and updated the frontend you access rather than need
+to rebuild the frontend container each time.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,109 @@
+services:
+  backend:
+    image: ghcr.io/ssciwr/mondey_backend:${MONDEY_DOCKER_IMAGE_TAG:-latest}
+    restart: always
+    build: ./mondey_backend
+    volumes:
+      - ${STATIC_FILES_PATH:-./static}:/app/static
+      - ${PRIVATE_FILES_PATH:-./private}:/app/private
+    environment:
+      - SECRET=${SECRET:-}
+      - DATABASE_HOST_MONDEYDB=${DATABASE_HOST_MONDEYDB:-mondeydb}
+      - DATABASE_HOST_USERSDB=${DATABASE_HOST_USERSDB:-usersdb}
+      - DATABASE_USER=${DATABASE_USER:-postgres}
+      - DATABASE_PASSWORD=${DATABASE_PASSWORD:-}
+      - DATABASE_PORT=${DATABASE_PORT:-5432}
+      - STATIC_FILES_PATH=/app/static
+      - PRIVATE_FILES_PATH=/app/private
+      - HOST=${HOST:-backend}
+      - PORT=${PORT:-80}
+      - SMTP_HOST=${SMTP_HOST:-email:587}
+      - SMTP_USERNAME=${SMTP_USERNAME:-}
+      - SMTP_PASSWORD=${SMTP_PASSWORD:-}
+      - RELOAD=false
+      - LOG_LEVEL=${LOG_LEVEL:-info}
+      - COOKIE_SECURE=${COOKIE_SECURE:-false}
+      - STATS_CRONTAB=${STATS_CRONTAB:-0 3 * * mon}
+      - DEEPL_API_KEY=${DEEPL_API_KEY:-}
+      - MONDEY_HOST=${MONDEY_HOST:-localhost}
+    depends_on:
+      - mondeydb
+      - usersdb
+      - email
+    logging:
+      driver: "local"
+      options:
+        max-size: "20m"
+        max-file: "25"
+  frontend-dev:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile.dev
+    restart: always
+    ports:
+      - "5173:5173"
+    volumes:
+      # Mount the entire frontend directory for hot reloading
+      - ./frontend:/app
+      # Use a named volume for node_modules to avoid conflicts
+      - frontend_node_modules:/app/node_modules
+    depends_on:
+      - backend
+    logging:
+      driver: "local"
+      options:
+        max-size: "20m"
+        max-file: "25"
+  mondeydb:
+    image: postgres:17-alpine
+    restart: always
+    shm_size: 128mb
+    volumes:
+      - ${POSTGRES_DATA_PATH_MONDEY:-./db/mondey}:/var/lib/postgresql/data
+      - ./db:/db
+    environment:
+      - POSTGRES_USER=${DATABASE_USER:-postgres}
+      - POSTGRES_PASSWORD=${DATABASE_PASSWORD:-}
+      - POSTGRES_DB=mondey
+    logging:
+      driver: "local"
+      options:
+        max-size: "20m"
+        max-file: "5"
+  usersdb:
+    image: postgres:17-alpine
+    restart: always
+    shm_size: 128mb
+    volumes:
+      - ${POSTGRES_DATA_PATH_USER:-./db/users}:/var/lib/postgresql/data
+      - ./db:/db
+    environment:
+      - POSTGRES_USER=${DATABASE_USER:-postgres}
+      - POSTGRES_PASSWORD=${DATABASE_PASSWORD:-}
+      - POSTGRES_DB=users
+    logging:
+      driver: "local"
+      options:
+        max-size: "20m"
+        max-file: "5"
+  email:
+    image: "boky/postfix"
+    hostname: mail.mondey.lkeegan.dev
+    restart: always
+    environment:
+      - RELAYHOST=${RELAYHOST:-}
+      - POSTFIX_myhostname=mail.mondey.lkeegan.dev
+      - POSTFIX_mydomain=mondey.lkeegan.dev
+      - ALLOWED_SENDER_DOMAINS=mondey.lkeegan.dev
+      - DKIM_AUTOGENERATE=true
+    volumes:
+      - ./opendkim-keys:/etc/opendkim/keys
+    logging:
+      driver: "local"
+      options:
+        max-size: "20m"
+        max-file: "3"
+
+
+volumes:
+  frontend_node_modules:

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,0 +1,25 @@
+FROM node:22-slim
+
+LABEL org.opencontainers.image.source=https://github.com/ssciwr/mondey
+LABEL org.opencontainers.image.description="MONDEY frontend development image"
+
+ENV MONDEY_API_URL=/api
+
+ENV VITE_MONDEY_API_URL=/api
+
+WORKDIR /app
+
+# Install pnpm globally
+RUN npm install -g pnpm
+
+# Copy package files first for better Docker layer caching
+COPY package.json pnpm-lock.yaml ./
+
+# Install dependencies
+RUN pnpm install
+
+# Expose the Vite dev server port
+EXPOSE 5173
+
+# Start the development server
+CMD ["pnpm", "run", "dev", "--host", "0.0.0.0"]

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,6 +3,13 @@ import { svelteTesting } from "@testing-library/svelte/vite";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig(({ mode }) => {
+	// Use Docker backend service in development when running in container
+	// Check if we're running in Docker by looking for the DOCKER environment variable
+	// or if the API URL is set to use the backend service
+	const isDocker =
+		process.env.VITE_MONDEY_API_URL === "/api" || process.env.DOCKER === "true";
+	const apiTarget = isDocker ? "http://backend:80" : "http://localhost:8000";
+
 	return {
 		plugins: [sveltekit(), svelteTesting()],
 		test: {
@@ -10,18 +17,18 @@ export default defineConfig(({ mode }) => {
 			environment: "jsdom",
 		},
 		server: {
-			host: "localhost",
+			host: "0.0.0.0", // Changed from localhost to 0.0.0.0 for Docker
 			strictPort: true,
 			proxy: {
-				"/api": "http://localhost:8000",
+				"/api": apiTarget,
 			},
 			port: 5173,
 		},
 		preview: {
-			host: "localhost",
+			host: "0.0.0.0", // Changed from localhost to 0.0.0.0 for Docker
 			strictPort: true,
 			proxy: {
-				"/api": "http://localhost:8000",
+				"/api": apiTarget,
 			},
 			port: 5173,
 		},


### PR DESCRIPTION
A local docker development version which runs the dev server, enabling us to change code and have it through the mounted volume hot reload while using docker for local development, rather than rebuilding.

@lkeegan I haven't fully got this working yet (don't believe it's far off) - do you have any thoughts on this kind of set up? Not sure it's worth investing time into at this stage and because this is a fairly bloated way of doing it (because Docker-Compose doesn't really support a "good" pattern of conditional logic, so you then end up with a dev docker-compose and dev Dockerfile)