### PR TITLE
Use dynamic env variables for all ports

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,35 @@
+# Change the SECRETVALU values to random alphanumeric strings. For APIs, like Deepgram, request a value, and then change APIVALUE it. Then, after all VALUEs are filled out, copy this to .env
+
+# Database configuration
+DATABASE_PASSWORD=SECRETVALUE
+DATABASE_HOST_MONDEYDB=localhost
+DATABASE_HOST_USERSDB=localhost
+DATABASE_USER=postgres
+DATABASE_PORT_MONDEYDB=5432
+DATABASE_PORT_USERSDB=5433
+
+# Backend server configuration
+SECRET=SECRETVALUE
+HOST=localhost
+PORT=8000
+SMTP_HOST=""
+LOG_LEVEL="debug"
+RELOAD=true
+COOKIE_SECURE=false
+STATS_CRONTAB="0 3 * * mon"
+
+# External services
+DEEPL_API_KEY=APIVALUE
+# Derived from VITE_HOST:VITE_PORT in /frontend/.env(.sample) for backend use - would be better if automated but this is okay
+MONDEY_HOST=localhost:5173
+
+# File paths
+STATIC_FILES_PATH=static
+PRIVATE_FILES_PATH=private
+
+# Testing
+E2E_TEST_USER_SQL_FILES=""
+E2E_TEST_MONDEY_SQL_FILES=""
+
+# Application settings
+MAX_CHILD_AGE_MONTHS=72

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ Thumbs.db
 .env
 .env.*
 !.env.example
+!.env.sample
 !.env.test
 */.svelte-kit
 */.venv

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -27,14 +27,7 @@ cd mondey
 openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 365 -nodes -subj '/CN=localhost'
 ```
 
-3. define settings in a .env file in the same folder as the `docker-compose.yml` file, eg:
-
-```
-SMTP_HOST=""
-SECRET="abc123"
-DATABASE_PASSWORD="abc123"
-LOG_LEVEL="debug"
-```
+3. define settings in a .env file in the same folder as the `docker-compose.yml` file. A sample .env.sample file is included in the root directory, which can be copied to .env, with the relevant VALUEs filled in(SECRETS/API keys)
 
 3. build and run the website locally in docker containers on your computer:
 

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,2 +1,0 @@
-# api location for local development:
-VITE_MONDEY_API_URL=http://localhost:5173/api

--- a/frontend/.env.sample
+++ b/frontend/.env.sample
@@ -1,0 +1,4 @@
+VITE_HOST=localhost
+VITE_PORT=5173
+VITE_API_PROXY_URL=http://localhost:8000
+VITE_MONDEY_API_URL=http://localhost:5173/api

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,11 +1,13 @@
 import { sveltekit } from "@sveltejs/kit/vite";
 import { svelteTesting } from "@testing-library/svelte/vite";
+import { loadEnv } from "vite";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig(({ mode }) => {
-	const host = process.env.VITE_HOST || "localhost";
-	const port = Number.parseInt(process.env.VITE_PORT || "5173", 10);
-	const apiUrl = process.env.VITE_API_PROXY_URL || "http://localhost:8000";
+	const env = loadEnv(mode, "../", "VITE_"); // because of this we could consolidate /frontend/.env into /.env too
+	const host = env.VITE_HOST || "localhost";
+	const port = Number.parseInt(env.VITE_PORT || "5173", 10);
+	const apiUrl = env.VITE_API_PROXY_URL || "http://localhost:8000";
 
 	return {
 		plugins: [sveltekit(), svelteTesting()],

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,6 +3,10 @@ import { svelteTesting } from "@testing-library/svelte/vite";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig(({ mode }) => {
+	const host = process.env.VITE_HOST || "localhost";
+	const port = Number.parseInt(process.env.VITE_PORT || "5173", 10);
+	const apiUrl = process.env.VITE_API_PROXY_URL || "http://localhost:8000";
+
 	return {
 		plugins: [sveltekit(), svelteTesting()],
 		test: {
@@ -10,20 +14,20 @@ export default defineConfig(({ mode }) => {
 			environment: "jsdom",
 		},
 		server: {
-			host: "localhost",
+			host,
 			strictPort: true,
 			proxy: {
-				"/api": "http://localhost:8000",
+				"/api": apiUrl,
 			},
-			port: 5173,
+			port,
 		},
 		preview: {
-			host: "localhost",
+			host,
 			strictPort: true,
 			proxy: {
-				"/api": "http://localhost:8000",
+				"/api": apiUrl,
 			},
-			port: 5173,
+			port,
 		},
 	};
 });

--- a/mondey_backend/src/mondey_backend/settings.py
+++ b/mondey_backend/src/mondey_backend/settings.py
@@ -6,7 +6,9 @@ from pydantic_settings import SettingsConfigDict
 
 class AppSettings(BaseSettings):
     # this will load settings from environment variables or an .env file if present
-    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
+    model_config = SettingsConfigDict(
+        env_file="../.env", env_file_encoding="utf-8", extra="ignore"
+    )
     # these defaults are for local development and are used if the environment variables are not set
     SECRET: str = "abc123"
     DATABASE_HOST_MONDEYDB: str = "localhost"


### PR DESCRIPTION
This moves the backend ENV variables to the root directory and provides sample .env files for development. It allows all ports (database, frontend, and backend) to be configured.

To avoid possible leaking of secrets, frontend and backend env variables are still split into two different files. But since frontend only loads VITE_ variables as you can see in /frontend/vite.config.ts, we could combine the two .env files into just one (and that way also only define ports once, e.g. Backend can still access VITE variables so ports/urls could be defined with VITE_, but frontend could only access the VITE ones).

To merge you need to update the .env in both / and /frontend and it would make sense to delete any .env you have in src/mondey_backend to avoid confusion.

The values, in this PR, should be the same as the previous defaults, so running local dev should not change.